### PR TITLE
Bump codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -36,7 +36,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The `test-coverage` workflow began failing on push to `main` at the Codecov CLI GPG verification step:

```
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
```

`covr` runs fine and produces coverage; the failure is entirely in `codecov-action@v6` verifying its downloaded CLI binary against a GPG public key it could not fetch. On `push` events `fail_ci_if_error` is `true`, so the hiccup aborts the job.

This bumps the pin from `v6` to the latest release `v7.0.0` (`fb8b3582c8e4def4969c97caa2f19720cb33a72f`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)