### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,4 +15,5 @@
 ^README\.Rmd$
 ^CODE_OF_CONDUCT\.md$
 ^\.ccache$
-^\.claude$
+^\.claude$^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/check.R
+++ b/R/check.R
@@ -10,8 +10,11 @@ check_classes <- function(x, y, x_name, y_name) {
 
   if (!identical(classes_x[!character], classes_y[!character])) {
     err(
-      "classes of variables in `", x_name, "` must match those in `",
-      y_name, "`"
+      "classes of variables in `",
+      x_name,
+      "` must match those in `",
+      y_name,
+      "`"
     )
   }
 

--- a/R/new-data.R
+++ b/R/new-data.R
@@ -32,22 +32,24 @@
 #' new_data(old_data, c("int", "dbl"))
 #' @export
 new_data <- function(
-    data,
-    seq = character(0),
-    ref = list(),
-    obs_only = list(character(0)),
-    length_out = 30) {
-
+  data,
+  seq = character(0),
+  ref = list(),
+  obs_only = list(character(0)),
+  length_out = 30
+) {
   if (!missing(ref)) {
     lifecycle::deprecate_warn(
-      "0.0.0.9020", "new_data(ref)",
+      "0.0.0.9020",
+      "new_data(ref)",
       details = "Use `xnew_data(data, col_name = 'new_value')`"
     )
   }
 
   if (!missing(obs_only)) {
     lifecycle::deprecate_warn(
-      "0.0.0.9020", "new_data(obs_only)",
+      "0.0.0.9020",
+      "new_data(obs_only)",
       details = "Use `xnew_data(data, xobs_only(col_name))`"
     )
   }
@@ -58,7 +60,9 @@ new_data <- function(
   chk_list(ref)
   chk_range(length_out, c(2L, 1000L))
 
-  if (isTRUE(obs_only)) obs_only <- list(seq)
+  if (isTRUE(obs_only)) {
+    obs_only <- list(seq)
+  }
   chk_list(obs_only)
   if (!all(map_lgl(obs_only, is.character))) {
     err("`obs_only` must be a list of character vectors")
@@ -70,10 +74,15 @@ new_data <- function(
       return(do.call("xnew_data", args = args))
     }
     seq <- paste(seq, collapse = ", ")
-    if(missing(length_out)) {
+    if (missing(length_out)) {
       length_out <- NULL
     }
-    text <- paste("xnew_data(data", seq, ".length_out = length_out)", sep = ", ")
+    text <- paste(
+      "xnew_data(data",
+      seq,
+      ".length_out = length_out)",
+      sep = ", "
+    )
     expr <- parse(text = text)
     return(eval(expr))
   }
@@ -93,7 +102,9 @@ new_data <- function(
   }
 
   if (length(ref)) {
-    if (!is_named(ref)) err("`ref` must be a named list")
+    if (!is_named(ref)) {
+      err("`ref` must be a named list")
+    }
 
     if (any(names(ref) %in% seq)) {
       wrn("`ref` should not contain variables in `seq`")
@@ -123,8 +134,10 @@ new_data <- function(
     new_value
   )
 
-  new_data <- expand.grid(c(new_seqs, new_ref, ref),
-    KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE
+  new_data <- expand.grid(
+    c(new_seqs, new_ref, ref),
+    KEEP.OUT.ATTRS = FALSE,
+    stringsAsFactors = FALSE
   )
   for (obo in obs_only) {
     new_data <- new_data %>% obs_only(data, obo)

--- a/R/new-seq.R
+++ b/R/new-seq.R
@@ -79,10 +79,11 @@ new_seq <- function(x, length_out = NULL, ..., obs_only = NULL) {
 #' @describeIn new_seq Generate new sequence of values for logical objects
 #' @export
 new_seq.logical <- function(
-    x,
-    length_out = NULL,
-    ...,
-    obs_only = NULL) {
+  x,
+  length_out = NULL,
+  ...,
+  obs_only = NULL
+) {
   if (is.null(length_out)) {
     length_out <- getOption("new_data.length_out_lgl", 2L)
   }
@@ -111,10 +112,11 @@ new_seq.logical <- function(
 #' @describeIn new_seq Generate new sequence of values for integer objects
 #' @export
 new_seq.integer <- function(
-    x,
-    length_out = NULL,
-    ...,
-    obs_only = NULL) {
+  x,
+  length_out = NULL,
+  ...,
+  obs_only = NULL
+) {
   if (is.null(length_out)) {
     length_out <- getOption("new_data.length_out_int", 30L)
   }
@@ -140,10 +142,11 @@ new_seq.integer <- function(
 #' @describeIn new_seq Generate new sequence of values for double objects
 #' @export
 new_seq.double <- function(
-    x,
-    length_out = NULL,
-    ...,
-    obs_only = NULL) {
+  x,
+  length_out = NULL,
+  ...,
+  obs_only = NULL
+) {
   if (is.null(length_out)) {
     length_out <- getOption("new_data.length_out_dbl", 30L)
   }
@@ -170,10 +173,11 @@ new_seq.double <- function(
 #' @describeIn new_seq Generate new sequence of values for character objects
 #' @export
 new_seq.character <- function(
-    x,
-    length_out = NULL,
-    ...,
-    obs_only = NULL) {
+  x,
+  length_out = NULL,
+  ...,
+  obs_only = NULL
+) {
   if (is.null(length_out)) {
     length_out <- getOption("new_data.length_out_chr", Inf)
   }
@@ -200,10 +204,11 @@ new_seq.character <- function(
 #' @describeIn new_seq Generate new sequence of values for factors
 #' @export
 new_seq.factor <- function(
-    x,
-    length_out = NULL,
-    ...,
-    obs_only = NULL) {
+  x,
+  length_out = NULL,
+  ...,
+  obs_only = NULL
+) {
   if (is.null(length_out)) {
     length_out <- getOption("new_data.length_out_chr", Inf)
   }
@@ -223,8 +228,7 @@ new_seq.factor <- function(
   if (!length(levels)) {
     return(factor(NA_character_, levels = levels))
   }
-  if (obs_only) {
-  }
+  if (obs_only) {}
   out <- if (obs_only) {
     as.integer(x)
   } else {
@@ -237,10 +241,11 @@ new_seq.factor <- function(
 #' @describeIn new_seq Generate new sequence of values for ordered factors
 #' @export
 new_seq.ordered <- function(
-    x,
-    length_out = NULL,
-    ...,
-    obs_only = NULL) {
+  x,
+  length_out = NULL,
+  ...,
+  obs_only = NULL
+) {
   if (is.null(length_out)) {
     length_out <- getOption("new_data.length_out_chr", Inf)
   }
@@ -272,10 +277,11 @@ new_seq.ordered <- function(
 #' @describeIn new_seq Generate new sequence of values for Date vectors
 #' @export
 new_seq.Date <- function(
-    x,
-    length_out = NULL,
-    ...,
-    obs_only = NULL) {
+  x,
+  length_out = NULL,
+  ...,
+  obs_only = NULL
+) {
   x %>%
     as.integer() %>%
     new_seq(length_out = length_out, obs_only = obs_only) %>%
@@ -285,10 +291,11 @@ new_seq.Date <- function(
 #' @describeIn new_seq Generate new sequence of values for POSIXct vectors
 #' @export
 new_seq.POSIXct <- function(
-    x,
-    length_out = NULL,
-    ...,
-    obs_only = NULL) {
+  x,
+  length_out = NULL,
+  ...,
+  obs_only = NULL
+) {
   tz <- attr(x, "tzone", exact = TRUE)
 
   x %>%
@@ -300,10 +307,11 @@ new_seq.POSIXct <- function(
 #' @describeIn new_seq Generate new sequence of values for hms vectors
 #' @export
 new_seq.hms <- function(
-    x,
-    length_out = NULL,
-    ...,
-    obs_only = NULL) {
+  x,
+  length_out = NULL,
+  ...,
+  obs_only = NULL
+) {
   x %>%
     as.integer() %>%
     new_seq(length_out = length_out, obs_only = obs_only) %>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -4,7 +4,11 @@ as.Date <- function(x, ...) {
 }
 
 as.POSIXct <- function(x, ...) {
-  base::as.POSIXct(x, ..., origin = structure(0, class = c("POSIXct", "POSIXt")))
+  base::as.POSIXct(
+    x,
+    ...,
+    origin = structure(0, class = c("POSIXct", "POSIXt"))
+  )
 }
 
 ordered <- function(x = character(), ...) {

--- a/R/xutils.R
+++ b/R/xutils.R
@@ -19,7 +19,11 @@ expand2 <- function(.data, ..., .default = NULL, .order = FALSE) {
   out <- tidyr::expand(.data, !!!quos)
 
   if (.order) {
-    out <- dplyr::select(out, !!!names(.data), !!!setdiff(names(out), names(.data)))
+    out <- dplyr::select(
+      out,
+      !!!names(.data),
+      !!!setdiff(names(out), names(.data))
+    )
   }
 
   out

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/scripts/build.R
+++ b/scripts/build.R
@@ -5,9 +5,11 @@ styler::style_pkg(
   filetype = c("R", "Rmd")
 )
 
-lintr::lint_package(linters = linters_with_defaults(
-  line_length_linter = line_length_linter(1000),
-  object_name_linter = object_name_linter(regexes = ".*"))
+lintr::lint_package(
+  linters = linters_with_defaults(
+    line_length_linter = line_length_linter(1000),
+    object_name_linter = object_name_linter(regexes = ".*")
+  )
 )
 
 lintr::lint_package()

--- a/tests/testthat/test-new-data.R
+++ b/tests/testthat/test-new-data.R
@@ -79,7 +79,10 @@ test_that("new_data ref works", {
 test_that("new_data ref overridden by seq", {
   withr::local_options(lifecycle_verbosity = "quiet")
 
-  testthat::expect_snapshot(expect_warning(new_data(Orange, seq = "age", ref = list(age = 118)), "`ref` should not contain variables in `seq`"))
+  testthat::expect_snapshot(expect_warning(
+    new_data(Orange, seq = "age", ref = list(age = 118)),
+    "`ref` should not contain variables in `seq`"
+  ))
 })
 
 test_that("new_data factor with 100 levels", {

--- a/tests/testthat/test-new-seq.R
+++ b/tests/testthat/test-new-seq.R
@@ -52,8 +52,14 @@ test_that("new_seq logical", {
   expect_identical(new_seq(c(TRUE, FALSE), obs_only = TRUE), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, TRUE), obs_only = TRUE), TRUE)
   expect_identical(new_seq(c(FALSE, FALSE), obs_only = TRUE), FALSE)
-  expect_identical(new_seq(c(FALSE, FALSE, TRUE), obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE, FALSE), obs_only = TRUE), c(FALSE, TRUE))
+  expect_identical(
+    new_seq(c(FALSE, FALSE, TRUE), obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE), obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
   # multiple value with missing
   expect_identical(new_seq(c(FALSE, TRUE, NA)), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, FALSE, NA)), c(FALSE, TRUE))
@@ -65,18 +71,33 @@ test_that("new_seq logical", {
   expect_identical(new_seq(c(TRUE, FALSE, NA), obs_only = TRUE), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, TRUE, NA), obs_only = TRUE), TRUE)
   expect_identical(new_seq(c(FALSE, FALSE, NA), obs_only = TRUE), FALSE)
-  expect_identical(new_seq(c(FALSE, FALSE, TRUE, NA), obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE, FALSE, NA), obs_only = TRUE), c(FALSE, TRUE))
+  expect_identical(
+    new_seq(c(FALSE, FALSE, TRUE, NA), obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE, NA), obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
   # length_out not count
   expect_error(new_seq(TRUE, length_out = -1), "`length_out` must be a count")
   expect_error(new_seq(TRUE, length_out = 0.5), "`length_out` must be a count")
-  expect_error(new_seq(TRUE, length_out = -1, obs_only = TRUE), "`length_out` must be a count")
-  expect_error(new_seq(TRUE, length_out = 0.5, obs_only = TRUE), "`length_out` must be a count")
+  expect_error(
+    new_seq(TRUE, length_out = -1, obs_only = TRUE),
+    "`length_out` must be a count"
+  )
+  expect_error(
+    new_seq(TRUE, length_out = 0.5, obs_only = TRUE),
+    "`length_out` must be a count"
+  )
   # length_out is 0
   expect_identical(new_seq(logical(), length_out = 0), logical())
   expect_identical(new_seq(NA, length_out = 0), logical())
   expect_identical(new_seq(TRUE, length_out = 0), logical())
-  expect_identical(new_seq(logical(), length_out = 0, obs_only = TRUE), logical())
+  expect_identical(
+    new_seq(logical(), length_out = 0, obs_only = TRUE),
+    logical()
+  )
   expect_identical(new_seq(NA, length_out = 0, obs_only = TRUE), logical())
   expect_identical(new_seq(TRUE, length_out = 0, obs_only = TRUE), logical())
   # length_out = 1
@@ -86,43 +107,121 @@ test_that("new_seq logical", {
   expect_identical(new_seq(c(FALSE, FALSE), length_out = 1), FALSE)
   expect_identical(new_seq(c(FALSE, FALSE, TRUE), length_out = 1), FALSE)
   expect_identical(new_seq(c(TRUE, TRUE, FALSE), length_out = 1), FALSE)
-  expect_identical(new_seq(c(FALSE, TRUE), length_out = 1, obs_only = TRUE), FALSE)
-  expect_identical(new_seq(c(TRUE, FALSE), length_out = 1, obs_only = TRUE), FALSE)
-  expect_identical(new_seq(c(TRUE, TRUE), length_out = 1, obs_only = TRUE), TRUE)
-  expect_identical(new_seq(c(FALSE, FALSE), length_out = 1, obs_only = TRUE), FALSE)
-  expect_identical(new_seq(c(FALSE, FALSE, TRUE), length_out = 1, obs_only = TRUE), FALSE)
-  expect_identical(new_seq(c(TRUE, TRUE, FALSE), length_out = 1, obs_only = TRUE), FALSE)
+  expect_identical(
+    new_seq(c(FALSE, TRUE), length_out = 1, obs_only = TRUE),
+    FALSE
+  )
+  expect_identical(
+    new_seq(c(TRUE, FALSE), length_out = 1, obs_only = TRUE),
+    FALSE
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE), length_out = 1, obs_only = TRUE),
+    TRUE
+  )
+  expect_identical(
+    new_seq(c(FALSE, FALSE), length_out = 1, obs_only = TRUE),
+    FALSE
+  )
+  expect_identical(
+    new_seq(c(FALSE, FALSE, TRUE), length_out = 1, obs_only = TRUE),
+    FALSE
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE), length_out = 1, obs_only = TRUE),
+    FALSE
+  )
   # length_out = 2
   expect_identical(new_seq(c(FALSE, TRUE), length_out = 2), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, FALSE), length_out = 2), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, TRUE), length_out = 2), c(FALSE, TRUE))
   expect_identical(new_seq(c(FALSE, FALSE), length_out = 2), c(FALSE, TRUE))
-  expect_identical(new_seq(c(FALSE, FALSE, TRUE), length_out = 2), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE, FALSE), length_out = 2), c(FALSE, TRUE))
-  expect_identical(new_seq(c(FALSE, TRUE), length_out = 2, obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, FALSE), length_out = 2, obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE), length_out = 2, obs_only = TRUE), TRUE)
-  expect_identical(new_seq(c(FALSE, FALSE), length_out = 2, obs_only = TRUE), FALSE)
-  expect_identical(new_seq(c(FALSE, FALSE, TRUE), length_out = 2, obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE, FALSE), length_out = 2, obs_only = TRUE), c(FALSE, TRUE))
+  expect_identical(
+    new_seq(c(FALSE, FALSE, TRUE), length_out = 2),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE), length_out = 2),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(FALSE, TRUE), length_out = 2, obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, FALSE), length_out = 2, obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE), length_out = 2, obs_only = TRUE),
+    TRUE
+  )
+  expect_identical(
+    new_seq(c(FALSE, FALSE), length_out = 2, obs_only = TRUE),
+    FALSE
+  )
+  expect_identical(
+    new_seq(c(FALSE, FALSE, TRUE), length_out = 2, obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE), length_out = 2, obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
   # length_out = 3
   expect_identical(new_seq(c(FALSE, TRUE), length_out = 3), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, FALSE), length_out = 3), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, TRUE), length_out = 3), c(FALSE, TRUE))
   expect_identical(new_seq(c(FALSE, FALSE), length_out = 3), c(FALSE, TRUE))
-  expect_identical(new_seq(c(FALSE, FALSE, TRUE), length_out = 3), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE, FALSE), length_out = 3), c(FALSE, TRUE))
-  expect_identical(new_seq(c(FALSE, TRUE), length_out = 3, obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, FALSE), length_out = 3, obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE), length_out = 3, obs_only = TRUE), TRUE)
-  expect_identical(new_seq(c(FALSE, FALSE), length_out = 3, obs_only = TRUE), FALSE)
-  expect_identical(new_seq(c(FALSE, FALSE, TRUE), length_out = 3, obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE, FALSE), length_out = 3, obs_only = TRUE), c(FALSE, TRUE))
+  expect_identical(
+    new_seq(c(FALSE, FALSE, TRUE), length_out = 3),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE), length_out = 3),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(FALSE, TRUE), length_out = 3, obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, FALSE), length_out = 3, obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE), length_out = 3, obs_only = TRUE),
+    TRUE
+  )
+  expect_identical(
+    new_seq(c(FALSE, FALSE), length_out = 3, obs_only = TRUE),
+    FALSE
+  )
+  expect_identical(
+    new_seq(c(FALSE, FALSE, TRUE), length_out = 3, obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE), length_out = 3, obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
   # length_out = Inf
-  expect_identical(new_seq(c(FALSE, FALSE, TRUE), length_out = Inf), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE, FALSE), length_out = Inf), c(FALSE, TRUE))
-  expect_identical(new_seq(c(FALSE, FALSE, TRUE), length_out = Inf, obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE, FALSE), length_out = Inf, obs_only = TRUE), c(FALSE, TRUE))
+  expect_identical(
+    new_seq(c(FALSE, FALSE, TRUE), length_out = Inf),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE), length_out = Inf),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(FALSE, FALSE, TRUE), length_out = Inf, obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE), length_out = Inf, obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
   # matrices and arrays
   expect_identical(new_seq(matrix(TRUE)), c(FALSE, TRUE))
   expect_identical(new_seq(array(TRUE)), c(FALSE, TRUE))
@@ -152,9 +251,36 @@ test_that("new_seq integer", {
   expect_identical(
     new_seq(c(100L, 1L)),
     c(
-      1L, 4L, 7L, 11L, 14L, 18L, 21L, 24L, 28L, 31L, 35L, 38L, 41L,
-      45L, 48L, 52L, 55L, 59L, 62L, 65L, 69L, 72L, 76L, 79L, 82L, 86L,
-      89L, 93L, 96L, 100L
+      1L,
+      4L,
+      7L,
+      11L,
+      14L,
+      18L,
+      21L,
+      24L,
+      28L,
+      31L,
+      35L,
+      38L,
+      41L,
+      45L,
+      48L,
+      52L,
+      55L,
+      59L,
+      62L,
+      65L,
+      69L,
+      72L,
+      76L,
+      79L,
+      82L,
+      86L,
+      89L,
+      93L,
+      96L,
+      100L
     )
   )
   expect_identical(new_seq(c(0L, 1L), obs_only = TRUE), c(0L, 1L))
@@ -176,9 +302,36 @@ test_that("new_seq integer", {
   expect_identical(
     new_seq(c(100L, 1L, NA)),
     c(
-      1L, 4L, 7L, 11L, 14L, 18L, 21L, 24L, 28L, 31L, 35L, 38L, 41L,
-      45L, 48L, 52L, 55L, 59L, 62L, 65L, 69L, 72L, 76L, 79L, 82L, 86L,
-      89L, 93L, 96L, 100L
+      1L,
+      4L,
+      7L,
+      11L,
+      14L,
+      18L,
+      21L,
+      24L,
+      28L,
+      31L,
+      35L,
+      38L,
+      41L,
+      45L,
+      48L,
+      52L,
+      55L,
+      59L,
+      62L,
+      65L,
+      69L,
+      72L,
+      76L,
+      79L,
+      82L,
+      86L,
+      89L,
+      93L,
+      96L,
+      100L
     )
   )
   expect_identical(new_seq(c(0L, 1L, NA), obs_only = TRUE), c(0L, 1L))
@@ -192,14 +345,26 @@ test_that("new_seq integer", {
   # length_out not count
   expect_error(new_seq(1L, length_out = -1), "`length_out` must be a count")
   expect_error(new_seq(1L, length_out = 0.5), "`length_out` must be a count")
-  expect_error(new_seq(1L, length_out = -1, obs_only = TRUE), "`length_out` must be a count")
-  expect_error(new_seq(1L, length_out = 0.5, obs_only = TRUE), "`length_out` must be a count")
+  expect_error(
+    new_seq(1L, length_out = -1, obs_only = TRUE),
+    "`length_out` must be a count"
+  )
+  expect_error(
+    new_seq(1L, length_out = 0.5, obs_only = TRUE),
+    "`length_out` must be a count"
+  )
   # length_out is 0
   expect_identical(new_seq(integer(), length_out = 0), integer())
   expect_identical(new_seq(NA_integer_, length_out = 0), integer())
   expect_identical(new_seq(1L, length_out = 0), integer())
-  expect_identical(new_seq(integer(), length_out = 0, obs_only = TRUE), integer())
-  expect_identical(new_seq(NA_integer_, length_out = 0, obs_only = TRUE), integer())
+  expect_identical(
+    new_seq(integer(), length_out = 0, obs_only = TRUE),
+    integer()
+  )
+  expect_identical(
+    new_seq(NA_integer_, length_out = 0, obs_only = TRUE),
+    integer()
+  )
   expect_identical(new_seq(1L, length_out = 0, obs_only = TRUE), integer())
   # length_out = 1
   expect_identical(new_seq(c(0L, 1L), length_out = 1), 0L)
@@ -227,14 +392,32 @@ test_that("new_seq integer", {
   expect_identical(new_seq(c(1L, 1L, 0L), length_out = 2), c(0L, 1L))
   expect_identical(new_seq(c(10L, 1L), length_out = 2), c(1L, 10L))
   expect_identical(new_seq(c(100L, 1L), length_out = 2), c(1L, 100L))
-  expect_identical(new_seq(c(0L, 1L), length_out = 2, obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 0L), length_out = 2, obs_only = TRUE), c(0L, 1L))
+  expect_identical(
+    new_seq(c(0L, 1L), length_out = 2, obs_only = TRUE),
+    c(0L, 1L)
+  )
+  expect_identical(
+    new_seq(c(1L, 0L), length_out = 2, obs_only = TRUE),
+    c(0L, 1L)
+  )
   expect_identical(new_seq(c(1L, 1L), length_out = 2, obs_only = TRUE), 1L)
   expect_identical(new_seq(c(0L, 0L), length_out = 2, obs_only = TRUE), 0L)
-  expect_identical(new_seq(c(0L, 0L, 1L), length_out = 2, obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 1L, 0L), length_out = 2, obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(10L, 1L), length_out = 2, obs_only = TRUE), c(1L, 10L))
-  expect_identical(new_seq(c(100L, 1L), length_out = 2, obs_only = TRUE), c(1L, 100L))
+  expect_identical(
+    new_seq(c(0L, 0L, 1L), length_out = 2, obs_only = TRUE),
+    c(0L, 1L)
+  )
+  expect_identical(
+    new_seq(c(1L, 1L, 0L), length_out = 2, obs_only = TRUE),
+    c(0L, 1L)
+  )
+  expect_identical(
+    new_seq(c(10L, 1L), length_out = 2, obs_only = TRUE),
+    c(1L, 10L)
+  )
+  expect_identical(
+    new_seq(c(100L, 1L), length_out = 2, obs_only = TRUE),
+    c(1L, 100L)
+  )
   # length_out = 3
   expect_identical(new_seq(c(0L, 1L), length_out = 3), c(0L, 1L))
   expect_identical(new_seq(c(1L, 0L), length_out = 3), c(0L, 1L))
@@ -244,19 +427,43 @@ test_that("new_seq integer", {
   expect_identical(new_seq(c(1L, 1L, 0L), length_out = 3), c(0L, 1L))
   expect_identical(new_seq(c(10L, 1L), length_out = 3), c(1L, 5L, 10L))
   expect_identical(new_seq(c(100L, 1L), length_out = 3), c(1L, 50L, 100L))
-  expect_identical(new_seq(c(0L, 1L), length_out = 3, obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 0L), length_out = 3, obs_only = TRUE), c(0L, 1L))
+  expect_identical(
+    new_seq(c(0L, 1L), length_out = 3, obs_only = TRUE),
+    c(0L, 1L)
+  )
+  expect_identical(
+    new_seq(c(1L, 0L), length_out = 3, obs_only = TRUE),
+    c(0L, 1L)
+  )
   expect_identical(new_seq(c(1L, 1L), length_out = 3, obs_only = TRUE), 1L)
   expect_identical(new_seq(c(0L, 0L), length_out = 3, obs_only = TRUE), 0L)
-  expect_identical(new_seq(c(0L, 0L, 1L), length_out = 3, obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 1L, 0L), length_out = 3, obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(10L, 1L), length_out = 3, obs_only = TRUE), c(1L, 10L))
-  expect_identical(new_seq(c(100L, 1L), length_out = 3, obs_only = TRUE), c(1L, 100L))
+  expect_identical(
+    new_seq(c(0L, 0L, 1L), length_out = 3, obs_only = TRUE),
+    c(0L, 1L)
+  )
+  expect_identical(
+    new_seq(c(1L, 1L, 0L), length_out = 3, obs_only = TRUE),
+    c(0L, 1L)
+  )
+  expect_identical(
+    new_seq(c(10L, 1L), length_out = 3, obs_only = TRUE),
+    c(1L, 10L)
+  )
+  expect_identical(
+    new_seq(c(100L, 1L), length_out = 3, obs_only = TRUE),
+    c(1L, 100L)
+  )
   # length_out = Inf
   expect_identical(new_seq(c(10L, 1L), length_out = Inf), 1:10)
   expect_identical(new_seq(c(100L, 1L), length_out = Inf), 1:100)
-  expect_identical(new_seq(c(10L, 1L), length_out = Inf, obs_only = TRUE), c(1L, 10L))
-  expect_identical(new_seq(c(100L, 1L), length_out = Inf, obs_only = TRUE), c(1L, 100L))
+  expect_identical(
+    new_seq(c(10L, 1L), length_out = Inf, obs_only = TRUE),
+    c(1L, 10L)
+  )
+  expect_identical(
+    new_seq(c(100L, 1L), length_out = Inf, obs_only = TRUE),
+    c(1L, 100L)
+  )
   # matrices and arrays
   expect_identical(new_seq(matrix(1L)), 1L)
   expect_identical(new_seq(array(1L)), 1L)
@@ -317,15 +524,24 @@ test_that("new_seq numeric", {
   # length_out not count
   expect_error(new_seq(1, length_out = -1), "`length_out` must be a count")
   expect_error(new_seq(1, length_out = 0.5), "`length_out` must be a count")
-  expect_error(new_seq(1, length_out = -1, obs_only = TRUE), "`length_out` must be a count")
-  expect_error(new_seq(1, length_out = 0.5, obs_only = TRUE), "`length_out` must be a count")
+  expect_error(
+    new_seq(1, length_out = -1, obs_only = TRUE),
+    "`length_out` must be a count"
+  )
+  expect_error(
+    new_seq(1, length_out = 0.5, obs_only = TRUE),
+    "`length_out` must be a count"
+  )
   # length_out is 0
   expect_identical(new_seq(double(), length_out = 0), double())
   expect_identical(new_seq(numeric(), length_out = 0), double())
   expect_identical(new_seq(NA_real_, length_out = 0), double())
   expect_identical(new_seq(1, length_out = 0), double())
   expect_identical(new_seq(double(), length_out = 0, obs_only = TRUE), double())
-  expect_identical(new_seq(numeric(), length_out = 0, obs_only = TRUE), double())
+  expect_identical(
+    new_seq(numeric(), length_out = 0, obs_only = TRUE),
+    double()
+  )
   expect_identical(new_seq(NA_real_, length_out = 0, obs_only = TRUE), double())
   expect_identical(new_seq(1, length_out = 0, obs_only = TRUE), double())
   # length_out = 1
@@ -358,10 +574,19 @@ test_that("new_seq numeric", {
   expect_identical(new_seq(c(1, 0), length_out = 2, obs_only = TRUE), c(0, 1))
   expect_identical(new_seq(c(1, 1), length_out = 2, obs_only = TRUE), 1)
   expect_identical(new_seq(c(0, 0), length_out = 2, obs_only = TRUE), 0)
-  expect_identical(new_seq(c(0, 0, 1), length_out = 2, obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 1, 0), length_out = 2, obs_only = TRUE), c(0, 1))
+  expect_identical(
+    new_seq(c(0, 0, 1), length_out = 2, obs_only = TRUE),
+    c(0, 1)
+  )
+  expect_identical(
+    new_seq(c(1, 1, 0), length_out = 2, obs_only = TRUE),
+    c(0, 1)
+  )
   expect_identical(new_seq(c(10, 1), length_out = 2, obs_only = TRUE), c(1, 10))
-  expect_identical(new_seq(c(100, 1), length_out = 2, obs_only = TRUE), c(1, 100))
+  expect_identical(
+    new_seq(c(100, 1), length_out = 2, obs_only = TRUE),
+    c(1, 100)
+  )
   # length_out = 3
   expect_identical(new_seq(c(0, 1), length_out = 3), c(0, 0.5, 1))
   expect_identical(new_seq(c(1, 0), length_out = 3), c(0, 0.5, 1))
@@ -375,10 +600,19 @@ test_that("new_seq numeric", {
   expect_identical(new_seq(c(1, 0), length_out = 3, obs_only = TRUE), c(0, 1))
   expect_identical(new_seq(c(1, 1), length_out = 3, obs_only = TRUE), 1)
   expect_identical(new_seq(c(0, 0), length_out = 3, obs_only = TRUE), 0)
-  expect_identical(new_seq(c(0, 0, 1), length_out = 3, obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 1, 0), length_out = 3, obs_only = TRUE), c(0, 1))
+  expect_identical(
+    new_seq(c(0, 0, 1), length_out = 3, obs_only = TRUE),
+    c(0, 1)
+  )
+  expect_identical(
+    new_seq(c(1, 1, 0), length_out = 3, obs_only = TRUE),
+    c(0, 1)
+  )
   expect_identical(new_seq(c(10, 1), length_out = 3, obs_only = TRUE), c(1, 10))
-  expect_identical(new_seq(c(100, 1), length_out = 3, obs_only = TRUE), c(1, 100))
+  expect_identical(
+    new_seq(c(100, 1), length_out = 3, obs_only = TRUE),
+    c(1, 100)
+  )
   # length_out = Inf
   expect_error(
     new_seq(c(0, 1), length_out = Inf),
@@ -409,16 +643,106 @@ test_that("new_seq character", {
   expect_identical(
     new_seq(as.character(1:100)),
     c(
-      "1", "10", "100", "11", "12", "13", "14", "15", "16", "17",
-      "18", "19", "2", "20", "21", "22", "23", "24", "25", "26", "27",
-      "28", "29", "3", "30", "31", "32", "33", "34", "35", "36", "37",
-      "38", "39", "4", "40", "41", "42", "43", "44", "45", "46", "47",
-      "48", "49", "5", "50", "51", "52", "53", "54", "55", "56", "57",
-      "58", "59", "6", "60", "61", "62", "63", "64", "65", "66", "67",
-      "68", "69", "7", "70", "71", "72", "73", "74", "75", "76", "77",
-      "78", "79", "8", "80", "81", "82", "83", "84", "85", "86", "87",
-      "88", "89", "9", "90", "91", "92", "93", "94", "95", "96", "97",
-      "98", "99"
+      "1",
+      "10",
+      "100",
+      "11",
+      "12",
+      "13",
+      "14",
+      "15",
+      "16",
+      "17",
+      "18",
+      "19",
+      "2",
+      "20",
+      "21",
+      "22",
+      "23",
+      "24",
+      "25",
+      "26",
+      "27",
+      "28",
+      "29",
+      "3",
+      "30",
+      "31",
+      "32",
+      "33",
+      "34",
+      "35",
+      "36",
+      "37",
+      "38",
+      "39",
+      "4",
+      "40",
+      "41",
+      "42",
+      "43",
+      "44",
+      "45",
+      "46",
+      "47",
+      "48",
+      "49",
+      "5",
+      "50",
+      "51",
+      "52",
+      "53",
+      "54",
+      "55",
+      "56",
+      "57",
+      "58",
+      "59",
+      "6",
+      "60",
+      "61",
+      "62",
+      "63",
+      "64",
+      "65",
+      "66",
+      "67",
+      "68",
+      "69",
+      "7",
+      "70",
+      "71",
+      "72",
+      "73",
+      "74",
+      "75",
+      "76",
+      "77",
+      "78",
+      "79",
+      "8",
+      "80",
+      "81",
+      "82",
+      "83",
+      "84",
+      "85",
+      "86",
+      "87",
+      "88",
+      "89",
+      "9",
+      "90",
+      "91",
+      "92",
+      "93",
+      "94",
+      "95",
+      "96",
+      "97",
+      "98",
+      "99"
     )
   )
   expect_identical(
@@ -471,9 +795,18 @@ test_that("new_seq character", {
   expect_identical(new_seq(c("1", "1", "0"), length_out = 3), c("1", "0"))
   expect_identical(new_seq(c("10", "1"), length_out = 3), c("1", "10"))
   expect_identical(new_seq(c("100", "1"), length_out = 3), c("1", "100"))
-  expect_identical(new_seq(c("100", "1", "2"), length_out = 3), c("1", "100", "2"))
-  expect_identical(new_seq(c("100", "1", "2", "3"), length_out = 3), c("1", "100", "2"))
-  expect_identical(new_seq(c("100", "1", "99", "3"), length_out = 3), c("1", "100", "3"))
+  expect_identical(
+    new_seq(c("100", "1", "2"), length_out = 3),
+    c("1", "100", "2")
+  )
+  expect_identical(
+    new_seq(c("100", "1", "2", "3"), length_out = 3),
+    c("1", "100", "2")
+  )
+  expect_identical(
+    new_seq(c("100", "1", "99", "3"), length_out = 3),
+    c("1", "100", "3")
+  )
   # length_out = Inf
   expect_identical(
     new_seq(as.character(1:100), length_out = Inf),
@@ -526,7 +859,10 @@ test_that("new_seq factor", {
     new_seq(factor(c("0", "0", "1"), levels = c("1", "0"))),
     factor(c("1", "0"), levels = c("1", "0"))
   )
-  expect_identical(new_seq(factor(as.character(1:100))), sort(factor(as.character(1:100))))
+  expect_identical(
+    new_seq(factor(as.character(1:100))),
+    sort(factor(as.character(1:100)))
+  )
   # multiple value with missing
   expect_identical(
     new_seq(factor(c("0", "1", NA), levels = c("0", "1"))),
@@ -556,15 +892,30 @@ test_that("new_seq factor", {
     new_seq(factor(c("0", "0", "1", NA), levels = c("1", "0"))),
     factor(c("1", "0"), levels = c("1", "0"))
   )
-  expect_identical(new_seq(factor(as.character(1:100, NA))), sort(factor(as.character(1:100, NA))))
+  expect_identical(
+    new_seq(factor(as.character(1:100, NA))),
+    sort(factor(as.character(1:100, NA)))
+  )
   # length_out not count
-  expect_error(new_seq(factor("1"), length_out = -1), "`length_out` must be a count")
-  expect_error(new_seq(factor("1"), length_out = 0.5), "`length_out` must be a count")
+  expect_error(
+    new_seq(factor("1"), length_out = -1),
+    "`length_out` must be a count"
+  )
+  expect_error(
+    new_seq(factor("1"), length_out = 0.5),
+    "`length_out` must be a count"
+  )
   # length_out is 0
   expect_identical(new_seq(factor(), length_out = 0), factor())
-  expect_identical(new_seq(factor(levels = "1"), length_out = 0), factor(levels = "1"))
+  expect_identical(
+    new_seq(factor(levels = "1"), length_out = 0),
+    factor(levels = "1")
+  )
   expect_identical(new_seq(factor(NA_character_), length_out = 0), factor())
-  expect_identical(new_seq(factor(NA_character_, levels = "1"), length_out = 0), factor(levels = "1"))
+  expect_identical(
+    new_seq(factor(NA_character_, levels = "1"), length_out = 0),
+    factor(levels = "1")
+  )
   expect_identical(new_seq(factor("1"), length_out = 0), factor(levels = "1"))
   # length_out = 1
   expect_identical(
@@ -596,7 +947,10 @@ test_that("new_seq factor", {
     factor("0", levels = c("0", "1", "2"))
   )
   expect_identical(
-    new_seq(factor(c("2", "1", "0"), levels = c("0", "1", "2")), length_out = 1),
+    new_seq(
+      factor(c("2", "1", "0"), levels = c("0", "1", "2")),
+      length_out = 1
+    ),
     factor("0", levels = c("0", "1", "2"))
   )
   # length_out = 2
@@ -629,15 +983,24 @@ test_that("new_seq factor", {
     factor(c("0", "1"), levels = c("0", "1", "2"))
   )
   expect_identical(
-    new_seq(factor(c("2", "1", "0"), levels = c("0", "1", "2")), length_out = 2),
+    new_seq(
+      factor(c("2", "1", "0"), levels = c("0", "1", "2")),
+      length_out = 2
+    ),
     factor(c("0", "1"), levels = c("0", "1", "2"))
   )
   expect_identical(
-    new_seq(factor(c("10", "1", "2"), levels = c("1", "10", "2")), length_out = 2),
+    new_seq(
+      factor(c("10", "1", "2"), levels = c("1", "10", "2")),
+      length_out = 2
+    ),
     factor(c("1", "10"), levels = c("1", "10", "2"))
   )
   expect_identical(
-    new_seq(factor(c("100", "1", "2"), levels = c("1", "10", "2")), length_out = 2),
+    new_seq(
+      factor(c("100", "1", "2"), levels = c("1", "10", "2")),
+      length_out = 2
+    ),
     factor(c("1", "10"), levels = c("1", "10", "2"))
   )
   # length_out = 3
@@ -670,20 +1033,32 @@ test_that("new_seq factor", {
     factor(c("0", "1", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
-    new_seq(factor(c("2", "1", "0"), levels = c("0", "1", "2")), length_out = 3),
+    new_seq(
+      factor(c("2", "1", "0"), levels = c("0", "1", "2")),
+      length_out = 3
+    ),
     factor(c("0", "1", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
-    new_seq(factor(c("10", "1", "2"), levels = c("1", "10", "2")), length_out = 3),
+    new_seq(
+      factor(c("10", "1", "2"), levels = c("1", "10", "2")),
+      length_out = 3
+    ),
     factor(c("1", "10", "2"), levels = c("1", "10", "2"))
   )
   expect_identical(
-    new_seq(factor(c("100", "1", "2"), levels = c("1", "2", "100")), length_out = 3),
+    new_seq(
+      factor(c("100", "1", "2"), levels = c("1", "2", "100")),
+      length_out = 3
+    ),
     factor(c("1", "2", "100"), levels = c("1", "2", "100"))
   )
   # length_out = Inf
   expect_identical(
-    new_seq(factor(c("100", "1", "2"), levels = c("1", "2", "100")), length_out = Inf),
+    new_seq(
+      factor(c("100", "1", "2"), levels = c("1", "2", "100")),
+      length_out = Inf
+    ),
     factor(c("1", "2", "100"), levels = c("1", "2", "100"))
   )
 })
@@ -693,7 +1068,10 @@ test_that("new_seq ordered", {
   expect_identical(new_seq(ordered()), ordered(NA))
   # missing value
   expect_identical(new_seq(ordered(NA)), ordered(NA))
-  expect_identical(new_seq(ordered(NA, levels = "1")), ordered("1", levels = "1"))
+  expect_identical(
+    new_seq(ordered(NA, levels = "1")),
+    ordered("1", levels = "1")
+  )
   # single value
   expect_identical(new_seq(ordered("1")), ordered("1"))
   expect_identical(new_seq(ordered("0")), ordered("0"))
@@ -730,7 +1108,10 @@ test_that("new_seq ordered", {
     new_seq(ordered(c("0", "0", "1"), levels = c("1", "0"))),
     ordered(c("1", "0"), levels = c("1", "0"))
   )
-  expect_identical(new_seq(ordered(as.character(1:100))), sort(ordered(as.character(1:100))))
+  expect_identical(
+    new_seq(ordered(as.character(1:100))),
+    sort(ordered(as.character(1:100)))
+  )
   # multiple value with missing
   expect_identical(
     new_seq(ordered(c("0", "1", NA), levels = c("0", "1"))),
@@ -760,15 +1141,30 @@ test_that("new_seq ordered", {
     new_seq(ordered(c("0", "0", "1", NA), levels = c("1", "0"))),
     ordered(c("1", "0"), levels = c("1", "0"))
   )
-  expect_identical(new_seq(ordered(as.character(1:100, NA))), sort(ordered(as.character(1:100, NA))))
+  expect_identical(
+    new_seq(ordered(as.character(1:100, NA))),
+    sort(ordered(as.character(1:100, NA)))
+  )
   # length_out not count
-  expect_error(new_seq(ordered("1"), length_out = -1), "`length_out` must be a count")
-  expect_error(new_seq(ordered("1"), length_out = 0.5), "`length_out` must be a count")
+  expect_error(
+    new_seq(ordered("1"), length_out = -1),
+    "`length_out` must be a count"
+  )
+  expect_error(
+    new_seq(ordered("1"), length_out = 0.5),
+    "`length_out` must be a count"
+  )
   # length_out is 0
   expect_identical(new_seq(ordered(), length_out = 0), ordered())
-  expect_identical(new_seq(ordered(levels = "1"), length_out = 0), ordered(levels = "1"))
+  expect_identical(
+    new_seq(ordered(levels = "1"), length_out = 0),
+    ordered(levels = "1")
+  )
   expect_identical(new_seq(ordered(NA_character_), length_out = 0), ordered())
-  expect_identical(new_seq(ordered(NA_character_, levels = "1"), length_out = 0), ordered(levels = "1"))
+  expect_identical(
+    new_seq(ordered(NA_character_, levels = "1"), length_out = 0),
+    ordered(levels = "1")
+  )
   expect_identical(new_seq(ordered("1"), length_out = 0), ordered(levels = "1"))
   # length_out = 1
   expect_identical(
@@ -800,7 +1196,10 @@ test_that("new_seq ordered", {
     ordered("1", levels = c("0", "1", "2"))
   )
   expect_identical(
-    new_seq(ordered(c("2", "1", "0"), levels = c("0", "1", "2")), length_out = 1),
+    new_seq(
+      ordered(c("2", "1", "0"), levels = c("0", "1", "2")),
+      length_out = 1
+    ),
     ordered("1", levels = c("0", "1", "2"))
   )
   # length_out = 2
@@ -833,15 +1232,24 @@ test_that("new_seq ordered", {
     ordered(c("0", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
-    new_seq(ordered(c("2", "1", "0"), levels = c("0", "1", "2")), length_out = 2),
+    new_seq(
+      ordered(c("2", "1", "0"), levels = c("0", "1", "2")),
+      length_out = 2
+    ),
     ordered(c("0", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
-    new_seq(ordered(c("10", "1", "2"), levels = c("1", "10", "2")), length_out = 2),
+    new_seq(
+      ordered(c("10", "1", "2"), levels = c("1", "10", "2")),
+      length_out = 2
+    ),
     ordered(c("1", "2"), levels = c("1", "10", "2"))
   )
   expect_identical(
-    new_seq(ordered(c("100", "1", "2"), levels = c("1", "10", "2")), length_out = 2),
+    new_seq(
+      ordered(c("100", "1", "2"), levels = c("1", "10", "2")),
+      length_out = 2
+    ),
     ordered(c("1", "2"), levels = c("1", "10", "2"))
   )
   # length_out = 3
@@ -874,20 +1282,32 @@ test_that("new_seq ordered", {
     ordered(c("0", "1", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
-    new_seq(ordered(c("2", "1", "0"), levels = c("0", "1", "2")), length_out = 3),
+    new_seq(
+      ordered(c("2", "1", "0"), levels = c("0", "1", "2")),
+      length_out = 3
+    ),
     ordered(c("0", "1", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
-    new_seq(ordered(c("10", "1", "2"), levels = c("1", "10", "2")), length_out = 3),
+    new_seq(
+      ordered(c("10", "1", "2"), levels = c("1", "10", "2")),
+      length_out = 3
+    ),
     ordered(c("1", "10", "2"), levels = c("1", "10", "2"))
   )
   expect_identical(
-    new_seq(ordered(c("100", "1", "2"), levels = c("1", "2", "100")), length_out = 3),
+    new_seq(
+      ordered(c("100", "1", "2"), levels = c("1", "2", "100")),
+      length_out = 3
+    ),
     ordered(c("1", "2", "100"), levels = c("1", "2", "100"))
   )
   # length_out = Inf
   expect_identical(
-    new_seq(ordered(c("100", "1", "2"), levels = c("1", "2", "100")), length_out = Inf),
+    new_seq(
+      ordered(c("100", "1", "2"), levels = c("1", "2", "100")),
+      length_out = Inf
+    ),
     ordered(c("1", "2", "100"), levels = c("1", "2", "100"))
   )
 })
@@ -897,16 +1317,34 @@ test_that("new_seq Date", {
   expect_identical(new_seq(as.Date(character(0))), as.Date(NA_integer_))
   expect_identical(new_seq(as.Date(integer(0))), as.Date(NA_integer_))
   expect_identical(new_seq(as.Date(double(0))), as.Date(NA_integer_))
-  expect_identical(new_seq(as.Date(character(0)), obs_only = TRUE), as.Date(NA_integer_))
-  expect_identical(new_seq(as.Date(integer(0)), obs_only = TRUE), as.Date(NA_integer_))
-  expect_identical(new_seq(as.Date(double(0)), obs_only = TRUE), as.Date(NA_integer_))
+  expect_identical(
+    new_seq(as.Date(character(0)), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
+  expect_identical(
+    new_seq(as.Date(integer(0)), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
+  expect_identical(
+    new_seq(as.Date(double(0)), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
   # missing value
   expect_identical(new_seq(as.Date(NA_character_)), as.Date(NA_integer_))
   expect_identical(new_seq(as.Date(NA_integer_)), as.Date(NA_integer_))
   expect_identical(new_seq(as.Date(NA_real_)), as.Date(NA_integer_))
-  expect_identical(new_seq(as.Date(NA_character_), obs_only = TRUE), as.Date(NA_integer_))
-  expect_identical(new_seq(as.Date(NA_integer_), obs_only = TRUE), as.Date(NA_integer_))
-  expect_identical(new_seq(as.Date(NA_real_), obs_only = TRUE), as.Date(NA_integer_))
+  expect_identical(
+    new_seq(as.Date(NA_character_), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
+  expect_identical(
+    new_seq(as.Date(NA_integer_), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
+  expect_identical(
+    new_seq(as.Date(NA_real_), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
   # single value
   expect_identical(new_seq(as.Date(1L)), as.Date(1L))
   expect_identical(new_seq(as.Date(1)), as.Date(1L))
@@ -925,18 +1363,60 @@ test_that("new_seq Date", {
   expect_identical(
     new_seq(as.Date(c(100L, 1L))),
     as.Date(c(
-      1L, 4L, 7L, 11L, 14L, 18L, 21L, 24L, 28L, 31L, 35L, 38L, 41L,
-      45L, 48L, 52L, 55L, 59L, 62L, 65L, 69L, 72L, 76L, 79L, 82L, 86L,
-      89L, 93L, 96L, 100L
+      1L,
+      4L,
+      7L,
+      11L,
+      14L,
+      18L,
+      21L,
+      24L,
+      28L,
+      31L,
+      35L,
+      38L,
+      41L,
+      45L,
+      48L,
+      52L,
+      55L,
+      59L,
+      62L,
+      65L,
+      69L,
+      72L,
+      76L,
+      79L,
+      82L,
+      86L,
+      89L,
+      93L,
+      96L,
+      100L
     ))
   )
-  expect_identical(new_seq(as.Date(c(0L, 1L)), obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 0L)), obs_only = TRUE), as.Date(c(0L, 1L)))
+  expect_identical(
+    new_seq(as.Date(c(0L, 1L)), obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 0L)), obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
   expect_identical(new_seq(as.Date(c(1L, 1L)), obs_only = TRUE), as.Date(1L))
   expect_identical(new_seq(as.Date(c(0L, 0L)), obs_only = TRUE), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(0L, 0L, 1L)), obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 1L, 0L)), obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(10L, 1L)), obs_only = TRUE), as.Date(c(1L, 10L)))
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L, 1L)), obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L, 0L)), obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), obs_only = TRUE),
+    as.Date(c(1L, 10L))
+  )
   expect_identical(
     new_seq(as.Date(c(100L, 1L)), obs_only = TRUE),
     as.Date(c(1L, 100L))
@@ -952,25 +1432,79 @@ test_that("new_seq Date", {
   expect_identical(
     new_seq(as.Date(c(100L, 1L, NA))),
     as.Date(c(
-      1L, 4L, 7L, 11L, 14L, 18L, 21L, 24L, 28L, 31L, 35L, 38L, 41L,
-      45L, 48L, 52L, 55L, 59L, 62L, 65L, 69L, 72L, 76L, 79L, 82L, 86L,
-      89L, 93L, 96L, 100L
+      1L,
+      4L,
+      7L,
+      11L,
+      14L,
+      18L,
+      21L,
+      24L,
+      28L,
+      31L,
+      35L,
+      38L,
+      41L,
+      45L,
+      48L,
+      52L,
+      55L,
+      59L,
+      62L,
+      65L,
+      69L,
+      72L,
+      76L,
+      79L,
+      82L,
+      86L,
+      89L,
+      93L,
+      96L,
+      100L
     ))
   )
-  expect_identical(new_seq(as.Date(c(0L, 1L, NA)), obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 0L, NA)), obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 1L, NA)), obs_only = TRUE), as.Date(1L))
-  expect_identical(new_seq(as.Date(c(0L, 0L, NA)), obs_only = TRUE), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(0L, 0L, 1L, NA)), obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 1L, 0L, NA)), obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(10L, 1L, NA)), obs_only = TRUE), as.Date(c(1L, 10L)))
+  expect_identical(
+    new_seq(as.Date(c(0L, 1L, NA)), obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 0L, NA)), obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L, NA)), obs_only = TRUE),
+    as.Date(1L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L, NA)), obs_only = TRUE),
+    as.Date(0L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L, 1L, NA)), obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L, 0L, NA)), obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L, NA)), obs_only = TRUE),
+    as.Date(c(1L, 10L))
+  )
   expect_identical(
     new_seq(as.Date(c(100L, 1L, NA)), obs_only = TRUE),
     as.Date(c(1L, 100L))
   )
   # length_out not count
-  expect_error(new_seq(as.Date(1L), length_out = -1), "`length_out` must be a count")
-  expect_error(new_seq(as.Date(1L), length_out = 0.5), "`length_out` must be a count")
+  expect_error(
+    new_seq(as.Date(1L), length_out = -1),
+    "`length_out` must be a count"
+  )
+  expect_error(
+    new_seq(as.Date(1L), length_out = 0.5),
+    "`length_out` must be a count"
+  )
   # length_out is 0
   expect_identical(
     new_seq(as.Date(integer()), length_out = 0),
@@ -1005,55 +1539,169 @@ test_that("new_seq Date", {
   expect_identical(new_seq(as.Date(c(1L, 1L, 0L)), length_out = 1), as.Date(0L))
   expect_identical(new_seq(as.Date(c(10L, 1L)), length_out = 1), as.Date(5L))
   expect_identical(new_seq(as.Date(c(100L, 1L)), length_out = 1), as.Date(50L))
-  expect_identical(new_seq(as.Date(c(0L, 1L)), length_out = 1, obs_only = TRUE), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(1L, 0L)), length_out = 1, obs_only = TRUE), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(1L, 1L)), length_out = 1, obs_only = TRUE), as.Date(1L))
-  expect_identical(new_seq(as.Date(c(0L, 0L)), length_out = 1, obs_only = TRUE), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(0L, 0L, 1L)), length_out = 1, obs_only = TRUE), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(1L, 1L, 0L)), length_out = 1, obs_only = TRUE), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(10L, 1L)), length_out = 1, obs_only = TRUE), as.Date(1L))
-  expect_identical(new_seq(as.Date(c(100L, 1L)), length_out = 1, obs_only = TRUE), as.Date(1L))
+  expect_identical(
+    new_seq(as.Date(c(0L, 1L)), length_out = 1, obs_only = TRUE),
+    as.Date(0L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 0L)), length_out = 1, obs_only = TRUE),
+    as.Date(0L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L)), length_out = 1, obs_only = TRUE),
+    as.Date(1L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L)), length_out = 1, obs_only = TRUE),
+    as.Date(0L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L, 1L)), length_out = 1, obs_only = TRUE),
+    as.Date(0L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L, 0L)), length_out = 1, obs_only = TRUE),
+    as.Date(0L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), length_out = 1, obs_only = TRUE),
+    as.Date(1L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(100L, 1L)), length_out = 1, obs_only = TRUE),
+    as.Date(1L)
+  )
   # length_out = 2
-  expect_identical(new_seq(as.Date(c(0L, 1L)), length_out = 2), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 0L)), length_out = 2), as.Date(c(0L, 1L)))
+  expect_identical(
+    new_seq(as.Date(c(0L, 1L)), length_out = 2),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 0L)), length_out = 2),
+    as.Date(c(0L, 1L))
+  )
   expect_identical(new_seq(as.Date(c(1L, 1L)), length_out = 2), as.Date(1L))
   expect_identical(new_seq(as.Date(c(0L, 0L)), length_out = 2), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(0L, 0L, 1L)), length_out = 2), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 1L, 0L)), length_out = 2), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(10L, 1L)), length_out = 2), as.Date(c(1L, 10L)))
-  expect_identical(new_seq(as.Date(c(100L, 1L)), length_out = 2), as.Date(c(1L, 100L)))
-  expect_identical(new_seq(as.Date(c(0L, 1L)), length_out = 2, obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 0L)), length_out = 2, obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 1L)), length_out = 2, obs_only = TRUE), as.Date(1L))
-  expect_identical(new_seq(as.Date(c(0L, 0L)), length_out = 2, obs_only = TRUE), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(0L, 0L, 1L)), length_out = 2, obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 1L, 0L)), length_out = 2, obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(10L, 1L)), length_out = 2, obs_only = TRUE), as.Date(c(1L, 10L)))
-  expect_identical(new_seq(as.Date(c(100L, 1L)), length_out = 2, obs_only = TRUE), as.Date(c(1L, 100L)))
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L, 1L)), length_out = 2),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L, 0L)), length_out = 2),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), length_out = 2),
+    as.Date(c(1L, 10L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(100L, 1L)), length_out = 2),
+    as.Date(c(1L, 100L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(0L, 1L)), length_out = 2, obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 0L)), length_out = 2, obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L)), length_out = 2, obs_only = TRUE),
+    as.Date(1L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L)), length_out = 2, obs_only = TRUE),
+    as.Date(0L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L, 1L)), length_out = 2, obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L, 0L)), length_out = 2, obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), length_out = 2, obs_only = TRUE),
+    as.Date(c(1L, 10L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(100L, 1L)), length_out = 2, obs_only = TRUE),
+    as.Date(c(1L, 100L))
+  )
   # length_out = 3
-  expect_identical(new_seq(as.Date(c(0L, 1L)), length_out = 3), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 0L)), length_out = 3), as.Date(c(0L, 1L)))
+  expect_identical(
+    new_seq(as.Date(c(0L, 1L)), length_out = 3),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 0L)), length_out = 3),
+    as.Date(c(0L, 1L))
+  )
   expect_identical(new_seq(as.Date(c(1L, 1L)), length_out = 3), as.Date(1L))
   expect_identical(new_seq(as.Date(c(0L, 0L)), length_out = 3), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(0L, 0L, 1L)), length_out = 3), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 1L, 0L)), length_out = 3), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(10L, 1L)), length_out = 3), as.Date(c(1L, 5L, 10L)))
-  expect_identical(new_seq(as.Date(c(100L, 1L)), length_out = 3), as.Date(c(1L, 50L, 100L)))
-  expect_identical(new_seq(as.Date(c(0L, 1L)), length_out = 3, obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 0L)), length_out = 3, obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 1L)), length_out = 3, obs_only = TRUE), as.Date(1L))
-  expect_identical(new_seq(as.Date(c(0L, 0L)), length_out = 3, obs_only = TRUE), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(0L, 0L, 1L)), length_out = 3, obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(1L, 1L, 0L)), length_out = 3, obs_only = TRUE), as.Date(c(0L, 1L)))
-  expect_identical(new_seq(as.Date(c(10L, 1L)), length_out = 3, obs_only = TRUE), as.Date(c(1L, 10L)))
-  expect_identical(new_seq(as.Date(c(100L, 1L)), length_out = 3, obs_only = TRUE), as.Date(c(1L, 100L)))
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L, 1L)), length_out = 3),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L, 0L)), length_out = 3),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), length_out = 3),
+    as.Date(c(1L, 5L, 10L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(100L, 1L)), length_out = 3),
+    as.Date(c(1L, 50L, 100L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(0L, 1L)), length_out = 3, obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 0L)), length_out = 3, obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L)), length_out = 3, obs_only = TRUE),
+    as.Date(1L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L)), length_out = 3, obs_only = TRUE),
+    as.Date(0L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(0L, 0L, 1L)), length_out = 3, obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L, 0L)), length_out = 3, obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), length_out = 3, obs_only = TRUE),
+    as.Date(c(1L, 10L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(100L, 1L)), length_out = 3, obs_only = TRUE),
+    as.Date(c(1L, 100L))
+  )
   # length_out = Inf
-  expect_identical(new_seq(as.Date(c(10L, 1L)), length_out = Inf), as.Date(1:10))
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), length_out = Inf),
+    as.Date(1:10)
+  )
   expect_identical(
     new_seq(as.Date(c(100L, 1L)), length_out = Inf),
     as.Date(c(1:100))
   )
-  expect_identical(new_seq(as.Date(c(10L, 1L)), length_out = Inf, obs_only = TRUE), as.Date(c(1L, 10L)))
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), length_out = Inf, obs_only = TRUE),
+    as.Date(c(1L, 10L))
+  )
   expect_identical(
     new_seq(as.Date(c(100L, 1L)), length_out = Inf, obs_only = TRUE),
     as.Date(c(1L, 100L))
@@ -1065,23 +1713,59 @@ test_that("new_seq POSIXct", {
   expect_identical(new_seq(as.POSIXct(character(0))), as.POSIXct(NA_integer_))
   expect_identical(new_seq(as.POSIXct(integer(0))), as.POSIXct(NA_integer_))
   expect_identical(new_seq(as.POSIXct(double(0))), as.POSIXct(NA_integer_))
-  expect_identical(new_seq(as.POSIXct(character(0), tz = "PST8PDT")), as.POSIXct(NA_integer_, tz = "PST8PDT"))
-  expect_identical(new_seq(as.POSIXct(integer(0), tz = "PST8PDT")), as.POSIXct(NA_integer_, tz = "PST8PDT"))
-  expect_identical(new_seq(as.POSIXct(double(0), tz = "PST8PDT")), as.POSIXct(NA_integer_, tz = "PST8PDT"))
+  expect_identical(
+    new_seq(as.POSIXct(character(0), tz = "PST8PDT")),
+    as.POSIXct(NA_integer_, tz = "PST8PDT")
+  )
+  expect_identical(
+    new_seq(as.POSIXct(integer(0), tz = "PST8PDT")),
+    as.POSIXct(NA_integer_, tz = "PST8PDT")
+  )
+  expect_identical(
+    new_seq(as.POSIXct(double(0), tz = "PST8PDT")),
+    as.POSIXct(NA_integer_, tz = "PST8PDT")
+  )
   # missing value
   expect_identical(new_seq(as.POSIXct(NA_character_)), as.POSIXct(NA_integer_))
   expect_identical(new_seq(as.POSIXct(NA_integer_)), as.POSIXct(NA_integer_))
   expect_identical(new_seq(as.POSIXct(NA_real_)), as.POSIXct(NA_integer_))
-  expect_identical(new_seq(as.POSIXct(NA_character_, tz = "PST8PDT")), as.POSIXct(NA_integer_, tz = "PST8PDT"))
-  expect_identical(new_seq(as.POSIXct(NA_integer_, tz = "PST8PDT")), as.POSIXct(NA_integer_, tz = "PST8PDT"))
-  expect_identical(new_seq(as.POSIXct(NA_real_, tz = "PST8PDT")), as.POSIXct(NA_integer_, tz = "PST8PDT"))
+  expect_identical(
+    new_seq(as.POSIXct(NA_character_, tz = "PST8PDT")),
+    as.POSIXct(NA_integer_, tz = "PST8PDT")
+  )
+  expect_identical(
+    new_seq(as.POSIXct(NA_integer_, tz = "PST8PDT")),
+    as.POSIXct(NA_integer_, tz = "PST8PDT")
+  )
+  expect_identical(
+    new_seq(as.POSIXct(NA_real_, tz = "PST8PDT")),
+    as.POSIXct(NA_integer_, tz = "PST8PDT")
+  )
   # single value
-  expect_identical(new_seq(as.POSIXct(1L, tz = "PST8PDT")), as.POSIXct(1L, tz = "PST8PDT"))
-  expect_identical(new_seq(as.POSIXct(1, tz = "PST8PDT")), as.POSIXct(1L, tz = "PST8PDT"))
-  expect_identical(new_seq(as.POSIXct(0L, tz = "PST8PDT")), as.POSIXct(0L, tz = "PST8PDT"))
-  expect_identical(new_seq(as.POSIXct(1L, tz = "PST8PDT")), as.POSIXct(1L, tz = "PST8PDT"))
-  expect_identical(new_seq(as.POSIXct(1, tz = "PST8PDT")), as.POSIXct(1L, tz = "PST8PDT"))
-  expect_identical(new_seq(as.POSIXct(0L, tz = "PST8PDT")), as.POSIXct(0L, tz = "PST8PDT"))
+  expect_identical(
+    new_seq(as.POSIXct(1L, tz = "PST8PDT")),
+    as.POSIXct(1L, tz = "PST8PDT")
+  )
+  expect_identical(
+    new_seq(as.POSIXct(1, tz = "PST8PDT")),
+    as.POSIXct(1L, tz = "PST8PDT")
+  )
+  expect_identical(
+    new_seq(as.POSIXct(0L, tz = "PST8PDT")),
+    as.POSIXct(0L, tz = "PST8PDT")
+  )
+  expect_identical(
+    new_seq(as.POSIXct(1L, tz = "PST8PDT")),
+    as.POSIXct(1L, tz = "PST8PDT")
+  )
+  expect_identical(
+    new_seq(as.POSIXct(1, tz = "PST8PDT")),
+    as.POSIXct(1L, tz = "PST8PDT")
+  )
+  expect_identical(
+    new_seq(as.POSIXct(0L, tz = "PST8PDT")),
+    as.POSIXct(0L, tz = "PST8PDT")
+  )
   # multiple value
   expect_identical(new_seq(as.POSIXct(c(0L, 1L))), as.POSIXct(c(0L, 1L)))
   expect_identical(new_seq(as.POSIXct(c(1L, 0L))), as.POSIXct(c(0L, 1L)))
@@ -1093,9 +1777,36 @@ test_that("new_seq POSIXct", {
   expect_identical(
     new_seq(as.POSIXct(c(100L, 1L))),
     as.POSIXct(c(
-      1L, 4L, 7L, 11L, 14L, 18L, 21L, 24L, 28L, 31L, 35L, 38L, 41L,
-      45L, 48L, 52L, 55L, 59L, 62L, 65L, 69L, 72L, 76L, 79L, 82L, 86L,
-      89L, 93L, 96L, 100L
+      1L,
+      4L,
+      7L,
+      11L,
+      14L,
+      18L,
+      21L,
+      24L,
+      28L,
+      31L,
+      35L,
+      38L,
+      41L,
+      45L,
+      48L,
+      52L,
+      55L,
+      59L,
+      62L,
+      65L,
+      69L,
+      72L,
+      76L,
+      79L,
+      82L,
+      86L,
+      89L,
+      93L,
+      96L,
+      100L
     ))
   )
   # multiple value with missing
@@ -1103,20 +1814,59 @@ test_that("new_seq POSIXct", {
   expect_identical(new_seq(as.POSIXct(c(1L, 0L, NA))), as.POSIXct(c(0L, 1L)))
   expect_identical(new_seq(as.POSIXct(c(1L, 1L, NA))), as.POSIXct(1L))
   expect_identical(new_seq(as.POSIXct(c(0L, 0L, NA))), as.POSIXct(0L))
-  expect_identical(new_seq(as.POSIXct(c(0L, 0L, 1L, NA))), as.POSIXct(c(0L, 1L)))
-  expect_identical(new_seq(as.POSIXct(c(1L, 1L, 0L, NA))), as.POSIXct(c(0L, 1L)))
+  expect_identical(
+    new_seq(as.POSIXct(c(0L, 0L, 1L, NA))),
+    as.POSIXct(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(1L, 1L, 0L, NA))),
+    as.POSIXct(c(0L, 1L))
+  )
   expect_identical(new_seq(as.POSIXct(c(10L, 1L, NA))), as.POSIXct(1:10))
   expect_identical(
     new_seq(as.POSIXct(c(100L, 1L, NA))),
     as.POSIXct(c(
-      1L, 4L, 7L, 11L, 14L, 18L, 21L, 24L, 28L, 31L, 35L, 38L, 41L,
-      45L, 48L, 52L, 55L, 59L, 62L, 65L, 69L, 72L, 76L, 79L, 82L, 86L,
-      89L, 93L, 96L, 100L
+      1L,
+      4L,
+      7L,
+      11L,
+      14L,
+      18L,
+      21L,
+      24L,
+      28L,
+      31L,
+      35L,
+      38L,
+      41L,
+      45L,
+      48L,
+      52L,
+      55L,
+      59L,
+      62L,
+      65L,
+      69L,
+      72L,
+      76L,
+      79L,
+      82L,
+      86L,
+      89L,
+      93L,
+      96L,
+      100L
     ))
   )
   # # length_out not count
-  expect_error(new_seq(as.POSIXct(1L), length_out = -1), "`length_out` must be a count")
-  expect_error(new_seq(as.POSIXct(1L), length_out = 0.5), "`length_out` must be a count")
+  expect_error(
+    new_seq(as.POSIXct(1L), length_out = -1),
+    "`length_out` must be a count"
+  )
+  expect_error(
+    new_seq(as.POSIXct(1L), length_out = 0.5),
+    "`length_out` must be a count"
+  )
   # length_out is 0
   expect_identical(
     new_seq(as.POSIXct(integer()), length_out = 0),
@@ -1143,37 +1893,121 @@ test_that("new_seq POSIXct", {
     as.POSIXct(integer(), tz = "PST8PDT")
   )
   # length_out = 1
-  expect_identical(new_seq(as.POSIXct(c(0L, 1L)), length_out = 1), as.POSIXct(0L))
-  expect_identical(new_seq(as.POSIXct(c(1L, 0L)), length_out = 1), as.POSIXct(0L))
-  expect_identical(new_seq(as.POSIXct(c(1L, 1L)), length_out = 1), as.POSIXct(1L))
-  expect_identical(new_seq(as.POSIXct(c(0L, 0L)), length_out = 1), as.POSIXct(0L))
-  expect_identical(new_seq(as.POSIXct(c(0L, 0L, 1L)), length_out = 1), as.POSIXct(0L))
-  expect_identical(new_seq(as.POSIXct(c(1L, 1L, 0L)), length_out = 1), as.POSIXct(0L))
-  expect_identical(new_seq(as.POSIXct(c(10L, 1L)), length_out = 1), as.POSIXct(5L))
-  expect_identical(new_seq(as.POSIXct(c(100L, 1L)), length_out = 1), as.POSIXct(50L))
-  expect_identical(new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), length_out = 1), as.POSIXct(50L, tz = "PST8PDT"))
+  expect_identical(
+    new_seq(as.POSIXct(c(0L, 1L)), length_out = 1),
+    as.POSIXct(0L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(1L, 0L)), length_out = 1),
+    as.POSIXct(0L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(1L, 1L)), length_out = 1),
+    as.POSIXct(1L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(0L, 0L)), length_out = 1),
+    as.POSIXct(0L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(0L, 0L, 1L)), length_out = 1),
+    as.POSIXct(0L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(1L, 1L, 0L)), length_out = 1),
+    as.POSIXct(0L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(10L, 1L)), length_out = 1),
+    as.POSIXct(5L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(100L, 1L)), length_out = 1),
+    as.POSIXct(50L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), length_out = 1),
+    as.POSIXct(50L, tz = "PST8PDT")
+  )
   # length_out = 2
-  expect_identical(new_seq(as.POSIXct(c(0L, 1L)), length_out = 2), as.POSIXct(c(0L, 1L)))
-  expect_identical(new_seq(as.POSIXct(c(1L, 0L)), length_out = 2), as.POSIXct(c(0L, 1L)))
-  expect_identical(new_seq(as.POSIXct(c(1L, 1L)), length_out = 2), as.POSIXct(1L))
-  expect_identical(new_seq(as.POSIXct(c(0L, 0L)), length_out = 2), as.POSIXct(0L))
-  expect_identical(new_seq(as.POSIXct(c(0L, 0L, 1L)), length_out = 2), as.POSIXct(c(0L, 1L)))
-  expect_identical(new_seq(as.POSIXct(c(1L, 1L, 0L)), length_out = 2), as.POSIXct(c(0L, 1L)))
-  expect_identical(new_seq(as.POSIXct(c(10L, 1L)), length_out = 2), as.POSIXct(c(1L, 10L)))
-  expect_identical(new_seq(as.POSIXct(c(100L, 1L)), length_out = 2), as.POSIXct(c(1L, 100L)))
-  expect_identical(new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), length_out = 2), as.POSIXct(c(1L, 100L), tz = "PST8PDT"))
+  expect_identical(
+    new_seq(as.POSIXct(c(0L, 1L)), length_out = 2),
+    as.POSIXct(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(1L, 0L)), length_out = 2),
+    as.POSIXct(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(1L, 1L)), length_out = 2),
+    as.POSIXct(1L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(0L, 0L)), length_out = 2),
+    as.POSIXct(0L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(0L, 0L, 1L)), length_out = 2),
+    as.POSIXct(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(1L, 1L, 0L)), length_out = 2),
+    as.POSIXct(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(10L, 1L)), length_out = 2),
+    as.POSIXct(c(1L, 10L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(100L, 1L)), length_out = 2),
+    as.POSIXct(c(1L, 100L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), length_out = 2),
+    as.POSIXct(c(1L, 100L), tz = "PST8PDT")
+  )
   # length_out = 3
-  expect_identical(new_seq(as.POSIXct(c(0L, 1L)), length_out = 3), as.POSIXct(c(0L, 1L)))
-  expect_identical(new_seq(as.POSIXct(c(1L, 0L)), length_out = 3), as.POSIXct(c(0L, 1L)))
-  expect_identical(new_seq(as.POSIXct(c(1L, 1L)), length_out = 3), as.POSIXct(1L))
-  expect_identical(new_seq(as.POSIXct(c(0L, 0L)), length_out = 3), as.POSIXct(0L))
-  expect_identical(new_seq(as.POSIXct(c(0L, 0L, 1L)), length_out = 3), as.POSIXct(c(0L, 1L)))
-  expect_identical(new_seq(as.POSIXct(c(1L, 1L, 0L)), length_out = 3), as.POSIXct(c(0L, 1L)))
-  expect_identical(new_seq(as.POSIXct(c(10L, 1L)), length_out = 3), as.POSIXct(c(1L, 5L, 10L)))
-  expect_identical(new_seq(as.POSIXct(c(100L, 1L)), length_out = 3), as.POSIXct(c(1L, 50L, 100L)))
-  expect_identical(new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), length_out = 3), as.POSIXct(c(1L, 50L, 100L), tz = "PST8PDT"))
+  expect_identical(
+    new_seq(as.POSIXct(c(0L, 1L)), length_out = 3),
+    as.POSIXct(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(1L, 0L)), length_out = 3),
+    as.POSIXct(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(1L, 1L)), length_out = 3),
+    as.POSIXct(1L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(0L, 0L)), length_out = 3),
+    as.POSIXct(0L)
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(0L, 0L, 1L)), length_out = 3),
+    as.POSIXct(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(1L, 1L, 0L)), length_out = 3),
+    as.POSIXct(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(10L, 1L)), length_out = 3),
+    as.POSIXct(c(1L, 5L, 10L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(100L, 1L)), length_out = 3),
+    as.POSIXct(c(1L, 50L, 100L))
+  )
+  expect_identical(
+    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), length_out = 3),
+    as.POSIXct(c(1L, 50L, 100L), tz = "PST8PDT")
+  )
   # length_out = Inf
-  expect_identical(new_seq(as.POSIXct(c(10L, 1L)), length_out = Inf), as.POSIXct(1:10))
+  expect_identical(
+    new_seq(as.POSIXct(c(10L, 1L)), length_out = Inf),
+    as.POSIXct(1:10)
+  )
   expect_identical(
     new_seq(as.POSIXct(c(100L, 1L)), length_out = Inf),
     as.POSIXct(c(1:100))
@@ -1208,9 +2042,36 @@ test_that("new_seq hms", {
   expect_identical(
     new_seq(as_hms(c(100L, 1L))),
     as_hms(c(
-      1L, 4L, 7L, 11L, 14L, 18L, 21L, 24L, 28L, 31L, 35L, 38L, 41L,
-      45L, 48L, 52L, 55L, 59L, 62L, 65L, 69L, 72L, 76L, 79L, 82L, 86L,
-      89L, 93L, 96L, 100L
+      1L,
+      4L,
+      7L,
+      11L,
+      14L,
+      18L,
+      21L,
+      24L,
+      28L,
+      31L,
+      35L,
+      38L,
+      41L,
+      45L,
+      48L,
+      52L,
+      55L,
+      59L,
+      62L,
+      65L,
+      69L,
+      72L,
+      76L,
+      79L,
+      82L,
+      86L,
+      89L,
+      93L,
+      96L,
+      100L
     ))
   )
   # multiple value with missing
@@ -1224,14 +2085,47 @@ test_that("new_seq hms", {
   expect_identical(
     new_seq(as_hms(c(100L, 1L, NA))),
     as_hms(c(
-      1L, 4L, 7L, 11L, 14L, 18L, 21L, 24L, 28L, 31L, 35L, 38L, 41L,
-      45L, 48L, 52L, 55L, 59L, 62L, 65L, 69L, 72L, 76L, 79L, 82L, 86L,
-      89L, 93L, 96L, 100L
+      1L,
+      4L,
+      7L,
+      11L,
+      14L,
+      18L,
+      21L,
+      24L,
+      28L,
+      31L,
+      35L,
+      38L,
+      41L,
+      45L,
+      48L,
+      52L,
+      55L,
+      59L,
+      62L,
+      65L,
+      69L,
+      72L,
+      76L,
+      79L,
+      82L,
+      86L,
+      89L,
+      93L,
+      96L,
+      100L
     ))
   )
   # length_out not count
-  expect_error(new_seq(as_hms(1L), length_out = -1), "`length_out` must be a count")
-  expect_error(new_seq(as_hms(1L), length_out = 0.5), "`length_out` must be a count")
+  expect_error(
+    new_seq(as_hms(1L), length_out = -1),
+    "`length_out` must be a count"
+  )
+  expect_error(
+    new_seq(as_hms(1L), length_out = 0.5),
+    "`length_out` must be a count"
+  )
   # length_out is 0
   expect_identical(
     new_seq(as_hms(integer()), length_out = 0),
@@ -1255,23 +2149,59 @@ test_that("new_seq hms", {
   expect_identical(new_seq(as_hms(c(10L, 1L)), length_out = 1), as_hms(5L))
   expect_identical(new_seq(as_hms(c(100L, 1L)), length_out = 1), as_hms(50L))
   # length_out = 2
-  expect_identical(new_seq(as_hms(c(0L, 1L)), length_out = 2), as_hms(c(0L, 1L)))
-  expect_identical(new_seq(as_hms(c(1L, 0L)), length_out = 2), as_hms(c(0L, 1L)))
+  expect_identical(
+    new_seq(as_hms(c(0L, 1L)), length_out = 2),
+    as_hms(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as_hms(c(1L, 0L)), length_out = 2),
+    as_hms(c(0L, 1L))
+  )
   expect_identical(new_seq(as_hms(c(1L, 1L)), length_out = 2), as_hms(1L))
   expect_identical(new_seq(as_hms(c(0L, 0L)), length_out = 2), as_hms(0L))
-  expect_identical(new_seq(as_hms(c(0L, 0L, 1L)), length_out = 2), as_hms(c(0L, 1L)))
-  expect_identical(new_seq(as_hms(c(1L, 1L, 0L)), length_out = 2), as_hms(c(0L, 1L)))
-  expect_identical(new_seq(as_hms(c(10L, 1L)), length_out = 2), as_hms(c(1L, 10L)))
-  expect_identical(new_seq(as_hms(c(100L, 1L)), length_out = 2), as_hms(c(1L, 100L)))
+  expect_identical(
+    new_seq(as_hms(c(0L, 0L, 1L)), length_out = 2),
+    as_hms(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as_hms(c(1L, 1L, 0L)), length_out = 2),
+    as_hms(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as_hms(c(10L, 1L)), length_out = 2),
+    as_hms(c(1L, 10L))
+  )
+  expect_identical(
+    new_seq(as_hms(c(100L, 1L)), length_out = 2),
+    as_hms(c(1L, 100L))
+  )
   # length_out = 3
-  expect_identical(new_seq(as_hms(c(0L, 1L)), length_out = 3), as_hms(c(0L, 1L)))
-  expect_identical(new_seq(as_hms(c(1L, 0L)), length_out = 3), as_hms(c(0L, 1L)))
+  expect_identical(
+    new_seq(as_hms(c(0L, 1L)), length_out = 3),
+    as_hms(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as_hms(c(1L, 0L)), length_out = 3),
+    as_hms(c(0L, 1L))
+  )
   expect_identical(new_seq(as_hms(c(1L, 1L)), length_out = 3), as_hms(1L))
   expect_identical(new_seq(as_hms(c(0L, 0L)), length_out = 3), as_hms(0L))
-  expect_identical(new_seq(as_hms(c(0L, 0L, 1L)), length_out = 3), as_hms(c(0L, 1L)))
-  expect_identical(new_seq(as_hms(c(1L, 1L, 0L)), length_out = 3), as_hms(c(0L, 1L)))
-  expect_identical(new_seq(as_hms(c(10L, 1L)), length_out = 3), as_hms(c(1L, 5L, 10L)))
-  expect_identical(new_seq(as_hms(c(100L, 1L)), length_out = 3), as_hms(c(1L, 50L, 100L)))
+  expect_identical(
+    new_seq(as_hms(c(0L, 0L, 1L)), length_out = 3),
+    as_hms(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as_hms(c(1L, 1L, 0L)), length_out = 3),
+    as_hms(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as_hms(c(10L, 1L)), length_out = 3),
+    as_hms(c(1L, 5L, 10L))
+  )
+  expect_identical(
+    new_seq(as_hms(c(100L, 1L)), length_out = 3),
+    as_hms(c(1L, 50L, 100L))
+  )
   # length_out = Inf
   expect_identical(new_seq(as_hms(c(10L, 1L)), length_out = Inf), as_hms(1:10))
   expect_identical(

--- a/tests/testthat/test-new-value.R
+++ b/tests/testthat/test-new-value.R
@@ -68,8 +68,14 @@ test_that("new_value integer", {
   expect_identical(new_value(array(1L)), 1L)
   # median
   expect_identical(new_value(c(0:1), obs_only = TRUE), as.integer(median(0:1)))
-  expect_identical(new_value(c(1:10), obs_only = TRUE), as.integer(median(1:10)))
-  expect_identical(new_value(c(2:10), obs_only = TRUE), as.integer(median(2:10)))
+  expect_identical(
+    new_value(c(1:10), obs_only = TRUE),
+    as.integer(median(1:10))
+  )
+  expect_identical(
+    new_value(c(2:10), obs_only = TRUE),
+    as.integer(median(2:10))
+  )
 })
 
 test_that("new_value integer obs_only", {
@@ -319,16 +325,34 @@ test_that("new_value Date", {
   expect_identical(new_value(as.Date(character())), as.Date(NA_integer_))
   expect_identical(new_value(as.Date(integer())), as.Date(NA_integer_))
   expect_identical(new_value(as.Date(double())), as.Date(NA_integer_))
-  expect_identical(new_value(as.Date(character()), obs_only = TRUE), as.Date(NA_integer_))
-  expect_identical(new_value(as.Date(integer()), obs_only = TRUE), as.Date(NA_integer_))
-  expect_identical(new_value(as.Date(double()), obs_only = TRUE), as.Date(NA_integer_))
+  expect_identical(
+    new_value(as.Date(character()), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
+  expect_identical(
+    new_value(as.Date(integer()), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
+  expect_identical(
+    new_value(as.Date(double()), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
   # missing value
   expect_identical(new_value(as.Date(NA_character_)), as.Date(NA_integer_))
   expect_identical(new_value(as.Date(NA_real_)), as.Date(NA_integer_))
   expect_identical(new_value(as.Date(NA_integer_)), as.Date(NA_integer_))
-  expect_identical(new_value(as.Date(NA_character_), obs_only = TRUE), as.Date(NA_integer_))
-  expect_identical(new_value(as.Date(NA_real_), obs_only = TRUE), as.Date(NA_integer_))
-  expect_identical(new_value(as.Date(NA_integer_), obs_only = TRUE), as.Date(NA_integer_))
+  expect_identical(
+    new_value(as.Date(NA_character_), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
+  expect_identical(
+    new_value(as.Date(NA_real_), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
+  expect_identical(
+    new_value(as.Date(NA_integer_), obs_only = TRUE),
+    as.Date(NA_integer_)
+  )
   # single value
   expect_identical(new_value(as.Date(1L)), as.Date(1L))
   expect_identical(new_value(as.Date(1)), as.Date(1L))
@@ -351,24 +375,54 @@ test_that("new_value Date", {
   expect_identical(new_value(as.Date(c(0, 1, NA))), as.Date(0L))
   expect_identical(new_value(as.Date(c(1, 2, NA))), as.Date(1L))
   expect_identical(new_value(as.Date(c(1, 3, NA))), as.Date(2L))
-  expect_identical(new_value(as.Date(c(0, 1, NA)), obs_only = TRUE), as.Date(0L))
-  expect_identical(new_value(as.Date(c(1, 2, NA)), obs_only = TRUE), as.Date(1L))
-  expect_identical(new_value(as.Date(c(1, 3, NA)), obs_only = TRUE), as.Date(1L))
+  expect_identical(
+    new_value(as.Date(c(0, 1, NA)), obs_only = TRUE),
+    as.Date(0L)
+  )
+  expect_identical(
+    new_value(as.Date(c(1, 2, NA)), obs_only = TRUE),
+    as.Date(1L)
+  )
+  expect_identical(
+    new_value(as.Date(c(1, 3, NA)), obs_only = TRUE),
+    as.Date(1L)
+  )
 })
 
 test_that("new_value POSIXct", {
   # zero length
   expect_identical(new_value(as.POSIXct(character())), as.POSIXct(NA_integer_))
-  expect_identical(new_value(as.POSIXct(character(), tz = "UTC")), as.POSIXct(NA_integer_, tz = "UTC"))
-  expect_identical(new_value(as.POSIXct(character(), tz = "PST8PDT")), as.POSIXct(NA_integer_, tz = "PST8PDT"))
+  expect_identical(
+    new_value(as.POSIXct(character(), tz = "UTC")),
+    as.POSIXct(NA_integer_, tz = "UTC")
+  )
+  expect_identical(
+    new_value(as.POSIXct(character(), tz = "PST8PDT")),
+    as.POSIXct(NA_integer_, tz = "PST8PDT")
+  )
   # missing value
-  expect_identical(new_value(as.POSIXct(NA_character_)), as.POSIXct(NA_integer_))
-  expect_identical(new_value(as.POSIXct(NA_character_, tz = "UTC")), as.POSIXct(NA_integer_, tz = "UTC"))
-  expect_identical(new_value(as.POSIXct(NA_character_, tz = "PST8PDT")), as.POSIXct(NA_integer_, tz = "PST8PDT"))
+  expect_identical(
+    new_value(as.POSIXct(NA_character_)),
+    as.POSIXct(NA_integer_)
+  )
+  expect_identical(
+    new_value(as.POSIXct(NA_character_, tz = "UTC")),
+    as.POSIXct(NA_integer_, tz = "UTC")
+  )
+  expect_identical(
+    new_value(as.POSIXct(NA_character_, tz = "PST8PDT")),
+    as.POSIXct(NA_integer_, tz = "PST8PDT")
+  )
   # single value
   expect_identical(new_value(as.POSIXct(1L)), as.POSIXct(1L))
-  expect_identical(new_value(as.POSIXct(1L, tz = "UTC")), as.POSIXct(1L, tz = "UTC"))
-  expect_identical(new_value(as.POSIXct(1L, tz = "PST8PDT")), as.POSIXct(1L, tz = "PST8PDT"))
+  expect_identical(
+    new_value(as.POSIXct(1L, tz = "UTC")),
+    as.POSIXct(1L, tz = "UTC")
+  )
+  expect_identical(
+    new_value(as.POSIXct(1L, tz = "PST8PDT")),
+    as.POSIXct(1L, tz = "PST8PDT")
+  )
   expect_identical(new_value(as.POSIXct(1)), as.POSIXct(1L))
   expect_identical(new_value(as.POSIXct(1.1)), as.POSIXct(1L))
   expect_identical(new_value(as.POSIXct(1.6)), as.POSIXct(1L))
@@ -378,12 +432,18 @@ test_that("new_value POSIXct", {
   expect_identical(new_value(as.POSIXct(c(1, 2))), as.POSIXct(1L))
   expect_identical(new_value(as.POSIXct(c(1, 3))), as.POSIXct(2L))
   expect_identical(new_value(as.POSIXct(c(1, 4))), as.POSIXct(2L))
-  expect_identical(new_value(as.POSIXct(c(1, 4), tz = "PST8PDT")), as.POSIXct(2L, tz = "PST8PDT"))
+  expect_identical(
+    new_value(as.POSIXct(c(1, 4), tz = "PST8PDT")),
+    as.POSIXct(2L, tz = "PST8PDT")
+  )
   # multiple values with missing
   expect_identical(new_value(as.POSIXct(c(0, 1, NA))), as.POSIXct(0L))
   expect_identical(new_value(as.POSIXct(c(1, 2, NA))), as.POSIXct(1L))
   expect_identical(new_value(as.POSIXct(c(1, 3, NA))), as.POSIXct(2L))
-  expect_identical(new_value(as.POSIXct(c(1, 4, NA), tz = "PST8PDT")), as.POSIXct(2L, tz = "PST8PDT"))
+  expect_identical(
+    new_value(as.POSIXct(c(1, 4, NA), tz = "PST8PDT")),
+    as.POSIXct(2L, tz = "PST8PDT")
+  )
 })
 
 test_that("new_value hms", {
@@ -401,7 +461,10 @@ test_that("new_value hms", {
   expect_identical(new_value(as_hms(c(0, 1))), as_hms(0))
   expect_identical(new_value(as_hms(c(1, 2))), as_hms(1))
   expect_identical(new_value(as_hms(c(1, 3))), as_hms(2))
-  expect_identical(new_value(as_hms(c("23:59:59", "00:00:02"))), as_hms("12:00:00"))
+  expect_identical(
+    new_value(as_hms(c("23:59:59", "00:00:02"))),
+    as_hms("12:00:00")
+  )
   # multiple values with missing
   expect_identical(new_value(as_hms(c(0, 1, NA))), as_hms(0))
   expect_identical(new_value(as_hms(c(1, 2, NA))), as_hms(1))

--- a/tests/testthat/test-obs-only.R
+++ b/tests/testthat/test-obs-only.R
@@ -2,7 +2,8 @@ test_that("obs_only", {
   withr::local_options(lifecycle_verbosity = "quiet")
 
   newdata <- expand.grid(
-    Tree = unique(Orange$Tree), age = c(1, 2, 3, 4, 5),
+    Tree = unique(Orange$Tree),
+    age = c(1, 2, 3, 4, 5),
     circumference = c(6, 7, 8, 9, 10)
   )
   data <- Orange[c(1, 35), ]
@@ -17,8 +18,10 @@ test_that("new_data obs_only", {
   withr::local_options(lifecycle_verbosity = "quiet")
 
   data <- expand.grid(
-    Fac1 = c("1", "2", "4"), Fac2 = c("1", "3"),
-    Fac3 = factor(1:2, levels = 1:3), Random = 1:2
+    Fac1 = c("1", "2", "4"),
+    Fac2 = c("1", "3"),
+    Fac3 = factor(1:2, levels = 1:3),
+    Random = 1:2
   )
   data <- data[as.character(data$Fac1) != as.character(data$Fac2), ]
 
@@ -37,6 +40,10 @@ test_that("new_data obs_only", {
     new_data(data, c("Fac3", "Random"), obs_only = TRUE)
     new_data(data, c("Fac1", "Fac2", "Fac3"), obs_only = TRUE)
     new_data(data, c("Fac1", "Fac2", "Fac3", "Random"), obs_only = TRUE)
-    new_data(data, c("Fac1", "Fac2", "Fac3", "Random"), obs_only = list("Fac1", "Fac2", "Fac3", "Random"))
+    new_data(
+      data,
+      c("Fac1", "Fac2", "Fac3", "Random"),
+      obs_only = list("Fac1", "Fac2", "Fac3", "Random")
+    )
   })
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,5 +1,7 @@
 test_that("classes", {
-  expect_equal(classes(Orange), c("ordered", "numeric", "numeric"),
+  expect_equal(
+    classes(Orange),
+    c("ordered", "numeric", "numeric"),
     ignore_attr = TRUE
   )
 })

--- a/tests/testthat/test-xcast.R
+++ b/tests/testthat/test-xcast.R
@@ -1,7 +1,17 @@
 test_that("xcast old_data", {
   testthat::expect_snapshot({
     old_data
-    xnew_data(old_data, xcast(lgl = 1, int = 7, dbl = 10L, chr = factor("x"), fct = "a rarity", hms = 1))
+    xnew_data(
+      old_data,
+      xcast(
+        lgl = 1,
+        int = 7,
+        dbl = 10L,
+        chr = factor("x"),
+        fct = "a rarity",
+        hms = 1
+      )
+    )
     xnew_data(old_data, xcast(lgl = 0, hms = "01:01:11"))
   })
   expect_error(xnew_data(old_data, xcast(dte = 1)), "Can't convert")
@@ -9,5 +19,8 @@ test_that("xcast old_data", {
   expect_error(xnew_data(old_data, xcast(dte = "2024-01-01")), "Can't convert")
   expect_error(xnew_data(old_data, xcast(dtt = 1)), "Can't convert")
   expect_error(xnew_data(old_data, xcast(dtt = 1L)), "Can't convert")
-  expect_error(xnew_data(old_data, xcast(dtt = "2024-01-01 10:30:42")), "Can't convert")
+  expect_error(
+    xnew_data(old_data, xcast(dtt = "2024-01-01 10:30:42")),
+    "Can't convert"
+  )
 })

--- a/tests/testthat/test-xnew-data.R
+++ b/tests/testthat/test-xnew-data.R
@@ -77,7 +77,10 @@ test_that("no column no row dataset", {
 
 test_that("factors", {
   data <- tibble::tibble(
-    period = factor(c(rep("before", 5), rep("after", 5)), levels = c("before", "after")),
+    period = factor(
+      c(rep("before", 5), rep("after", 5)),
+      levels = c("before", "after")
+    ),
     year = 2001:2010,
     annual = factor(year, levels = 2000:2010),
     ordered = ordered(year)
@@ -112,8 +115,10 @@ test_that("xnew_data called twice works", {
 test_that("xnew_data factor with 100 levels", {
   withr::local_options(lifecycle_verbosity = "quiet")
 
-  data <- tibble::tibble(fct = factor(1:100, levels = 1:100),
-                         dbl = seq(1, 100, length.out = 100))
+  data <- tibble::tibble(
+    fct = factor(1:100, levels = 1:100),
+    dbl = seq(1, 100, length.out = 100)
+  )
 
   testthat::expect_snapshot({
     data


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)