### PR TITLE
Standardize new_seq()/new_value() args to dotted names (#43)

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -21,5 +21,7 @@ import(chk)
 import(rlang)
 importFrom(hms,as_hms)
 importFrom(lifecycle,deprecated)
-importFrom(tibble,"%>%")
-importFrom(tibble,as_tibble)
+importFrom(tibble,
+  "%>%",
+  as_tibble
+)

--- a/R/new-seq.R
+++ b/R/new-seq.R
@@ -7,7 +7,7 @@
 #' is 30 evenly space values across the range of the data.
 #' Missing values are always removed unless it's the only value
 #' or the object is zero length.
-#' The length of the sequence can be varied using the `length_out` argument
+#' The length of the sequence can be varied using the `.length_out` argument
 #' which gives the reference value when 1 and can even be 0.
 #' For integer objects the sequence is the unique integers.
 #' For character objects it's the actual values sorted by
@@ -40,29 +40,29 @@
 #' new_seq(NA_real_)
 #' # or the object is zero length
 #' new_seq(numeric())
-#' # the length of the sequence can be varied using the length_out argument
-#' new_seq(c(1, 4), length_out = 3)
-#' new_seq(c(1, 4), length_out = 2)
+#' # the length of the sequence can be varied using the .length_out argument
+#' new_seq(c(1, 4), .length_out = 3)
+#' new_seq(c(1, 4), .length_out = 2)
 #' # which gives the reference value when 1
-#' new_seq(c(1, 4), length_out = 1)
+#' new_seq(c(1, 4), .length_out = 1)
 #' # and can even be 0
-#' new_seq(c(1, 4), length_out = 0)
+#' new_seq(c(1, 4), .length_out = 0)
 #' # for integer objects the sequence is the unique integers
 #' new_seq(c(1L, 4L))
 #' new_seq(c(1L, 100L))
 #' # for character objects it's the actual values sorted by
 #' # how common they are followed by their actual value
 #' new_seq(c("a", "c", "c", "b", "b"))
-#' new_seq(c("a", "c", "c", "b", "b"), length_out = 2)
+#' new_seq(c("a", "c", "c", "b", "b"), .length_out = 2)
 #' # for factors its the factor levels in order
 #' new_seq(factor(c("a", "b", "c", "c"), levels = c("b", "a", "g")))
 #' # with the trailing levels dropped first
 #' new_seq(factor(c("a", "b", "c", "c"), levels = c("b", "a", "g")),
-#'   length_out = 2
+#'   .length_out = 2
 #' )
 #' # for ordered factors the intermediate levels are dropped first
 #' new_seq(ordered(c("a", "b", "c", "c"), levels = c("b", "a", "g")),
-#'   length_out = 2
+#'   .length_out = 2
 #' )
 #' # for Date vectors it's the unique dates
 #' new_seq(as.Date(c("2000-01-01", "2000-01-04")))
@@ -73,7 +73,7 @@
 #'   tz = "PST8PDT"
 #' ))
 #' # for logical objects the longest possible sequence is `c(TRUE, FALSE)`
-#' new_seq(c(TRUE, TRUE, FALSE), length_out = 3)
+#' new_seq(c(TRUE, TRUE, FALSE), .length_out = 3)
 #' @export
 new_seq <- function(
   x,

--- a/R/new-seq.R
+++ b/R/new-seq.R
@@ -21,9 +21,11 @@
 #' For logical objects the longest possible sequence is `c(TRUE, FALSE)`.
 #'
 #' @param x The object to generate the sequence from.
-#' @param length_out The maximum length of the sequence.
+#' @param .length_out The maximum length of the sequence.
 #' @inheritParams rlang::args_dots_empty
-#' @param obs_only A flag specifying whether to only use observed values.
+#' @param .obs_only A flag specifying whether to only use observed values.
+#' @param length_out Use `.length_out` instead.
+#' @param obs_only Use `.obs_only` instead.
 #' @returns A vector of the same class as the object.
 #' @seealso [new_value()] and [new_data()].
 #' @examples
@@ -71,39 +73,63 @@
 #' # for logical objects the longest possible sequence is `c(TRUE, FALSE)`
 #' new_seq(c(TRUE, TRUE, FALSE), length_out = 3)
 #' @export
-new_seq <- function(x, length_out = NULL, ..., obs_only = NULL) {
+new_seq <- function(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+) {
   chk_unused(...)
   UseMethod("new_seq")
+}
+
+# Fold the old `length_out`/`obs_only` spellings into `.length_out`/`.obs_only`.
+# Methods coalesce for themselves because `UseMethod()` does not propagate
+# values remapped in the generic body.
+new_seq_args <- function(.length_out, .obs_only, length_out, obs_only) {
+  list(
+    .length_out = .length_out %||% length_out,
+    .obs_only = .obs_only %||% obs_only
+  )
 }
 
 #' @describeIn new_seq Generate new sequence of values for logical objects
 #' @export
 new_seq.logical <- function(
   x,
-  length_out = NULL,
+  .length_out = NULL,
   ...,
+  .obs_only = NULL,
+  length_out = NULL,
   obs_only = NULL
 ) {
-  if (is.null(length_out)) {
-    length_out <- getOption("new_data.length_out_lgl", 2L)
-  }
-  chk_count(length_out)
+  chk_unused(...)
+  args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
+  .length_out <- args$.length_out
+  .obs_only <- args$.obs_only
 
-  if (is.null(obs_only)) {
-    obs_only <- getOption("new_data.obs_only", FALSE)
+  if (is.null(.length_out)) {
+    .length_out <- getOption("new_data.length_out_lgl", 2L)
   }
-  chk_flag(obs_only)
+  chk_count(.length_out)
 
-  if (length_out == 0L) {
+  if (is.null(.obs_only)) {
+    .obs_only <- getOption("new_data.obs_only", FALSE)
+  }
+  chk_flag(.obs_only)
+
+  if (.length_out == 0L) {
     return(logical())
   }
-  if (obs_only) {
+  if (.obs_only) {
     if (all(is.na(x))) {
       return(NA)
     }
-    return(obs_only1(x, length_out, first = TRUE))
+    return(obs_only1(x, .length_out, first = TRUE))
   }
-  if (length_out == 1L) {
+  if (.length_out == 1L) {
     return(FALSE)
   }
   return(c(FALSE, TRUE))
@@ -113,82 +139,103 @@ new_seq.logical <- function(
 #' @export
 new_seq.integer <- function(
   x,
-  length_out = NULL,
+  .length_out = NULL,
   ...,
+  .obs_only = NULL,
+  length_out = NULL,
   obs_only = NULL
 ) {
-  if (is.null(length_out)) {
-    length_out <- getOption("new_data.length_out_int", 30L)
-  }
-  chk_count(length_out)
+  chk_unused(...)
+  args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
+  .length_out <- args$.length_out
+  .obs_only <- args$.obs_only
 
-  if (is.null(obs_only)) {
-    obs_only <- getOption("new_data.obs_only", FALSE)
+  if (is.null(.length_out)) {
+    .length_out <- getOption("new_data.length_out_int", 30L)
   }
-  chk_flag(obs_only)
+  chk_count(.length_out)
 
-  if (length_out == 0L) {
+  if (is.null(.obs_only)) {
+    .obs_only <- getOption("new_data.obs_only", FALSE)
+  }
+  chk_flag(.obs_only)
+
+  if (.length_out == 0L) {
     return(integer())
   }
   if (all(is.na(x))) {
     return(NA_integer_)
   }
-  if (obs_only) {
-    return(obs_only1(x, length_out))
+  if (.obs_only) {
+    return(obs_only1(x, .length_out))
   }
-  seq1(x, length_out, integer = TRUE)
+  seq1(x, .length_out, integer = TRUE)
 }
 
 #' @describeIn new_seq Generate new sequence of values for double objects
 #' @export
 new_seq.double <- function(
   x,
-  length_out = NULL,
+  .length_out = NULL,
   ...,
+  .obs_only = NULL,
+  length_out = NULL,
   obs_only = NULL
 ) {
-  if (is.null(length_out)) {
-    length_out <- getOption("new_data.length_out_dbl", 30L)
-  }
-  chk_count(length_out)
-  chk_lt(length_out, Inf)
+  chk_unused(...)
+  args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
+  .length_out <- args$.length_out
+  .obs_only <- args$.obs_only
 
-  if (is.null(obs_only)) {
-    obs_only <- getOption("new_data.obs_only", FALSE)
+  if (is.null(.length_out)) {
+    .length_out <- getOption("new_data.length_out_dbl", 30L)
   }
-  chk_flag(obs_only)
+  chk_count(.length_out)
+  chk_lt(.length_out, Inf)
 
-  if (length_out == 0L) {
+  if (is.null(.obs_only)) {
+    .obs_only <- getOption("new_data.obs_only", FALSE)
+  }
+  chk_flag(.obs_only)
+
+  if (.length_out == 0L) {
     return(double())
   }
   if (all(is.na(x))) {
     return(NA_real_)
   }
-  if (obs_only) {
-    return(obs_only1(x, length_out))
+  if (.obs_only) {
+    return(obs_only1(x, .length_out))
   }
-  seq1(x, length_out)
+  seq1(x, .length_out)
 }
 
 #' @describeIn new_seq Generate new sequence of values for character objects
 #' @export
 new_seq.character <- function(
   x,
-  length_out = NULL,
+  .length_out = NULL,
   ...,
+  .obs_only = NULL,
+  length_out = NULL,
   obs_only = NULL
 ) {
-  if (is.null(length_out)) {
-    length_out <- getOption("new_data.length_out_chr", Inf)
-  }
-  chk_count(length_out)
+  chk_unused(...)
+  args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
+  .length_out <- args$.length_out
+  .obs_only <- args$.obs_only
 
-  if (is.null(obs_only)) {
-    obs_only <- getOption("new_data.obs_only", FALSE)
+  if (is.null(.length_out)) {
+    .length_out <- getOption("new_data.length_out_chr", Inf)
   }
-  chk_flag(obs_only)
+  chk_count(.length_out)
 
-  if (length_out == 0L) {
+  if (is.null(.obs_only)) {
+    .obs_only <- getOption("new_data.obs_only", FALSE)
+  }
+  chk_flag(.obs_only)
+
+  if (.length_out == 0L) {
     return(character())
   }
   if (all(is.na(x))) {
@@ -197,7 +244,7 @@ new_seq.character <- function(
   table <- x %>% table()
   char <- names(table[order(table * -1, names(table))])
   factor(char, levels = char) %>%
-    new_seq(length_out = length_out, obs_only = TRUE) %>%
+    new_seq(.length_out = .length_out, .obs_only = TRUE) %>%
     as.character()
 }
 
@@ -205,36 +252,42 @@ new_seq.character <- function(
 #' @export
 new_seq.factor <- function(
   x,
-  length_out = NULL,
+  .length_out = NULL,
   ...,
+  .obs_only = NULL,
+  length_out = NULL,
   obs_only = NULL
 ) {
-  if (is.null(length_out)) {
-    length_out <- getOption("new_data.length_out_chr", Inf)
-  }
-  chk_count(length_out)
+  chk_unused(...)
+  args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
+  .length_out <- args$.length_out
+  .obs_only <- args$.obs_only
 
-  if (is.null(obs_only)) {
-    obs_only <- getOption("new_data.obs_only", FALSE)
+  if (is.null(.length_out)) {
+    .length_out <- getOption("new_data.length_out_chr", Inf)
   }
-  chk_flag(obs_only)
+  chk_count(.length_out)
+
+  if (is.null(.obs_only)) {
+    .obs_only <- getOption("new_data.obs_only", FALSE)
+  }
+  chk_flag(.obs_only)
 
   levels <- levels(x)
   nlevels <- length(levels)
 
-  if (length_out == 0L) {
+  if (.length_out == 0L) {
     return(factor(levels = levels))
   }
   if (!length(levels)) {
     return(factor(NA_character_, levels = levels))
   }
-  if (obs_only) {}
-  out <- if (obs_only) {
+  out <- if (.obs_only) {
     as.integer(x)
   } else {
     1:nlevels
   }
-  indices <- obs_only1(out, length_out = length_out, first = TRUE)
+  indices <- obs_only1(out, length_out = .length_out, first = TRUE)
   factor(levels[indices], levels = levels)
 }
 
@@ -242,35 +295,42 @@ new_seq.factor <- function(
 #' @export
 new_seq.ordered <- function(
   x,
-  length_out = NULL,
+  .length_out = NULL,
   ...,
+  .obs_only = NULL,
+  length_out = NULL,
   obs_only = NULL
 ) {
-  if (is.null(length_out)) {
-    length_out <- getOption("new_data.length_out_chr", Inf)
-  }
-  chk_count(length_out)
+  chk_unused(...)
+  args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
+  .length_out <- args$.length_out
+  .obs_only <- args$.obs_only
 
-  if (is.null(obs_only)) {
-    obs_only <- getOption("new_data.obs_only", FALSE)
+  if (is.null(.length_out)) {
+    .length_out <- getOption("new_data.length_out_chr", Inf)
   }
-  chk_flag(obs_only)
+  chk_count(.length_out)
+
+  if (is.null(.obs_only)) {
+    .obs_only <- getOption("new_data.obs_only", FALSE)
+  }
+  chk_flag(.obs_only)
 
   levels <- levels(x)
   nlevels <- length(levels)
 
-  if (length_out == 0L) {
+  if (.length_out == 0L) {
     return(ordered(levels = levels))
   }
   if (!nlevels) {
     return(ordered(NA_character_, levels = levels))
   }
-  out <- if (obs_only) {
+  out <- if (.obs_only) {
     as.integer(x)
   } else {
     1:nlevels
   }
-  indices <- new_seq(out, length_out = length_out, obs_only = TRUE)
+  indices <- new_seq(out, .length_out = .length_out, .obs_only = TRUE)
   ordered(levels[indices], levels = levels)
 }
 
@@ -278,13 +338,18 @@ new_seq.ordered <- function(
 #' @export
 new_seq.Date <- function(
   x,
-  length_out = NULL,
+  .length_out = NULL,
   ...,
+  .obs_only = NULL,
+  length_out = NULL,
   obs_only = NULL
 ) {
+  chk_unused(...)
+  args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
+
   x %>%
     as.integer() %>%
-    new_seq(length_out = length_out, obs_only = obs_only) %>%
+    new_seq(.length_out = args$.length_out, .obs_only = args$.obs_only) %>%
     as.Date()
 }
 
@@ -292,15 +357,19 @@ new_seq.Date <- function(
 #' @export
 new_seq.POSIXct <- function(
   x,
-  length_out = NULL,
+  .length_out = NULL,
   ...,
+  .obs_only = NULL,
+  length_out = NULL,
   obs_only = NULL
 ) {
+  chk_unused(...)
+  args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
   tz <- attr(x, "tzone", exact = TRUE)
 
   x %>%
     as.integer() %>%
-    new_seq(length_out = length_out, obs_only = obs_only) %>%
+    new_seq(.length_out = args$.length_out, .obs_only = args$.obs_only) %>%
     as.POSIXct(tz = tz)
 }
 
@@ -308,12 +377,17 @@ new_seq.POSIXct <- function(
 #' @export
 new_seq.hms <- function(
   x,
-  length_out = NULL,
+  .length_out = NULL,
   ...,
+  .obs_only = NULL,
+  length_out = NULL,
   obs_only = NULL
 ) {
+  chk_unused(...)
+  args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
+
   x %>%
     as.integer() %>%
-    new_seq(length_out = length_out, obs_only = obs_only) %>%
+    new_seq(.length_out = args$.length_out, .obs_only = args$.obs_only) %>%
     as_hms()
 }

--- a/R/new-seq.R
+++ b/R/new-seq.R
@@ -24,8 +24,10 @@
 #' @param .length_out The maximum length of the sequence.
 #' @inheritParams rlang::args_dots_empty
 #' @param .obs_only A flag specifying whether to only use observed values.
-#' @param length_out Use `.length_out` instead.
-#' @param obs_only Use `.obs_only` instead.
+#' @param length_out `r lifecycle::badge("deprecated")` Use `.length_out`
+#'   instead.
+#' @param obs_only `r lifecycle::badge("deprecated")` Use `.obs_only`
+#'   instead.
 #' @returns A vector of the same class as the object.
 #' @seealso [new_value()] and [new_data()].
 #' @examples
@@ -78,21 +80,39 @@ new_seq <- function(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 ) {
   chk_unused(...)
+  if (lifecycle::is_present(length_out)) {
+    lifecycle::deprecate_warn(
+      "0.1.0",
+      "new_seq(length_out)",
+      "new_seq(.length_out)"
+    )
+  }
+  if (lifecycle::is_present(obs_only)) {
+    lifecycle::deprecate_warn(
+      "0.1.0",
+      "new_seq(obs_only)",
+      "new_seq(.obs_only)"
+    )
+  }
   UseMethod("new_seq")
 }
 
-# Fold the old `length_out`/`obs_only` spellings into `.length_out`/`.obs_only`.
-# Methods coalesce for themselves because `UseMethod()` does not propagate
-# values remapped in the generic body.
+# Fold deprecated `length_out`/`obs_only` into `.length_out`/`.obs_only`.
+# The deprecation warning is emitted by the generic (correct caller
+# attribution); methods coalesce silently because `UseMethod()` does not
+# propagate values remapped in the generic body.
 new_seq_args <- function(.length_out, .obs_only, length_out, obs_only) {
-  list(
-    .length_out = .length_out %||% length_out,
-    .obs_only = .obs_only %||% obs_only
-  )
+  if (lifecycle::is_present(length_out)) {
+    .length_out <- length_out
+  }
+  if (lifecycle::is_present(obs_only)) {
+    .obs_only <- obs_only
+  }
+  list(.length_out = .length_out, .obs_only = .obs_only)
 }
 
 #' @describeIn new_seq Generate new sequence of values for logical objects
@@ -102,8 +122,8 @@ new_seq.logical <- function(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 ) {
   chk_unused(...)
   args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
@@ -142,8 +162,8 @@ new_seq.integer <- function(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 ) {
   chk_unused(...)
   args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
@@ -179,8 +199,8 @@ new_seq.double <- function(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 ) {
   chk_unused(...)
   args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
@@ -217,8 +237,8 @@ new_seq.character <- function(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 ) {
   chk_unused(...)
   args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
@@ -255,8 +275,8 @@ new_seq.factor <- function(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 ) {
   chk_unused(...)
   args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
@@ -298,8 +318,8 @@ new_seq.ordered <- function(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 ) {
   chk_unused(...)
   args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
@@ -341,8 +361,8 @@ new_seq.Date <- function(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 ) {
   chk_unused(...)
   args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
@@ -360,8 +380,8 @@ new_seq.POSIXct <- function(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 ) {
   chk_unused(...)
   args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)
@@ -380,8 +400,8 @@ new_seq.hms <- function(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 ) {
   chk_unused(...)
   args <- new_seq_args(.length_out, .obs_only, length_out, obs_only)

--- a/R/new-value.R
+++ b/R/new-value.R
@@ -3,8 +3,8 @@
 #' Generate a new reference value for a vector.
 #'
 #' By default the reference value for double vectors is the mean,
-#' unless obs_only = TRUE, in which case its the median of the unique values.
-#' For integer vectors it's the floored mean unless obs_only = TRUE, in which case
+#' unless .obs_only = TRUE, in which case its the median of the unique values.
+#' For integer vectors it's the floored mean unless .obs_only = TRUE, in which case
 #' it's also the median of the unique values.
 #' For character vectors it's the minimum of the most common values while
 #' for factors it's the first level.
@@ -19,8 +19,8 @@
 #' @examples
 #' # the reference value for objects of class numeric is the mean
 #' new_value(c(1, 4))
-#' # unless obs_only = TRUE, in which case its the median of the unique values
-#' new_value(c(1, 4), obs_only = TRUE)
+#' # unless .obs_only = TRUE, in which case its the median of the unique values
+#' new_value(c(1, 4), .obs_only = TRUE)
 #'
 #' # for integer objects it's the floored mean
 #' new_value(c(1L, 4L))
@@ -35,9 +35,9 @@
 #' new_value(ordered(c("a", "b", "c", "c"), levels = c("b", "a", "g")))
 #' new_value(as.Date(c("2000-01-01", "2000-01-04")))
 #' new_value(hms::as_hms(c("00:00:01", "00:00:04")))
-#' new_value(as.POSIXct(c("2000-01-01 00:00:01", "2000-01-01 00:00:04")),
-#'   tzone = "PST8PDT"
-#' )
+#' new_value(as.POSIXct(c("2000-01-01 00:00:01", "2000-01-01 00:00:04"),
+#'   tz = "PST8PDT"
+#' ))
 #' new_value(c(TRUE, FALSE, TRUE))
 #'
 #' @export

--- a/R/new-value.R
+++ b/R/new-value.R
@@ -41,8 +41,15 @@
 #' new_value(c(TRUE, FALSE, TRUE))
 #'
 #' @export
-new_value <- function(x, ..., .obs_only = NULL, obs_only = NULL) {
+new_value <- function(x, ..., .obs_only = NULL, obs_only = deprecated()) {
   chk_unused(...)
-  .obs_only <- .obs_only %||% obs_only
+  if (lifecycle::is_present(obs_only)) {
+    lifecycle::deprecate_warn(
+      "0.1.0",
+      "new_value(obs_only)",
+      "new_value(.obs_only)"
+    )
+    .obs_only <- obs_only
+  }
   new_seq(x, .length_out = 1L, .obs_only = .obs_only)
 }

--- a/R/new-value.R
+++ b/R/new-value.R
@@ -41,6 +41,8 @@
 #' new_value(c(TRUE, FALSE, TRUE))
 #'
 #' @export
-new_value <- function(x, ..., obs_only = NULL) {
-  new_seq(x, length_out = 1L, obs_only = obs_only)
+new_value <- function(x, ..., .obs_only = NULL, obs_only = NULL) {
+  chk_unused(...)
+  .obs_only <- .obs_only %||% obs_only
+  new_seq(x, .length_out = 1L, .obs_only = .obs_only)
 }

--- a/R/xnew-data.R
+++ b/R/xnew-data.R
@@ -63,7 +63,7 @@ quo_translate_xnew_data <- function(quo, length_out) {
 
 expr_translate_xnew_data <- function(expr, length_out) {
   if (is_symbol(expr)) {
-    expr(xnew_seq(!!expr, length_out = !!length_out))
+    expr(xnew_seq(!!expr, .length_out = !!length_out))
   } else {
     expr
   }

--- a/R/xnew-data.R
+++ b/R/xnew-data.R
@@ -30,13 +30,13 @@
 #' xnew_data(data, annual)
 #'
 #' # The user can specify the length of a sequence.
-#' xnew_data(data, xnew_seq(annual, length_out = 3))
+#' xnew_data(data, xnew_seq(annual, .length_out = 3))
 #'
 #' # And only allow observed values.
-#' xnew_data(data, xnew_seq(annual, length_out = 3, obs_only = TRUE))
+#' xnew_data(data, xnew_seq(annual, .length_out = 3, .obs_only = TRUE))
 #'
 #' # With multiple variables all combinations are produced
-#' xnew_data(data, period, xnew_seq(annual, length_out = 3, obs_only = TRUE))
+#' xnew_data(data, period, xnew_seq(annual, .length_out = 3, .obs_only = TRUE))
 #'
 #' # To only preserve observed combinations use
 #' xnew_data(data, xobs_only(period, annual))

--- a/R/xnew-seq.R
+++ b/R/xnew-seq.R
@@ -17,7 +17,7 @@
 #'   d = c("a", "b", "c")
 #' )
 #'
-#' xnew_data(data, a, b = new_seq(b, length_out = 3), xnew_seq(d, length_out = 2))
+#' xnew_data(data, a, b = new_seq(b, .length_out = 3), xnew_seq(d, .length_out = 2))
 xnew_seq <- function(x, ...) {
   expr <- ensym(x)
   out <- new_seq(x, ...)

--- a/R/xobs-only.R
+++ b/R/xobs-only.R
@@ -34,7 +34,7 @@ quo_translate_xobs_only <- function(quo, length_out) {
 
 expr_translate_xobs_only <- function(expr, length_out) {
   if (is_symbol(expr)) {
-    expr(xnew_seq(!!expr, length_out = !!length_out, obs_only = TRUE))
+    expr(xnew_seq(!!expr, .length_out = !!length_out, .obs_only = TRUE))
   } else {
     expr
   }

--- a/R/xobs-only.R
+++ b/R/xobs-only.R
@@ -15,7 +15,7 @@
 #' )
 #' xnew_data(data, period, annual)
 #' xnew_data(data, xobs_only(period, annual))
-#' xnew_data(data, xobs_only(period, xnew_seq(annual, length_out = 3)))
+#' xnew_data(data, xobs_only(period, xnew_seq(annual, .length_out = 3)))
 xobs_only <- function(..., .length_out = NULL, .data = xnew_data_env$data) {
   quos <- enquos(...)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -81,7 +81,7 @@ These values can be overridden by setting the following options:
 
 When programming it is strongly recommended that the user explicitly specify the length of each sequence individually.
 ```{r}
-xnew_data(old_data, lgl, xnew_seq(int, length_out = 3))
+xnew_data(old_data, lgl, xnew_seq(int, .length_out = 3))
 ```
 
 A third alternative is to specify the length of all the sequences in the data set but this can result in less common character strings or later factor or ordered levels being dropped.
@@ -94,12 +94,12 @@ xnew_data(old_data, dbl, int, .length_out = 2)
 
 The user can also indicate whether only observed values should be used in the sequence.
 ```{r}
-xnew_data(old_data, xnew_seq(int, length_out = 3, obs_only = TRUE))
+xnew_data(old_data, xnew_seq(int, .length_out = 3, .obs_only = TRUE))
 ```
 
 The `xobs_only()` function can be used to filter out unobserved values after the sequence has been generated.
 ```{r}
-xnew_data(old_data, xobs_only(xnew_seq(int, length_out = 3)))
+xnew_data(old_data, xobs_only(xnew_seq(int, .length_out = 3)))
 ```
 
 and when two or more variables are specified all combinations are used.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ When programming it is strongly recommended that the user explicitly
 specify the length of each sequence individually.
 
 ``` r
-xnew_data(old_data, lgl, xnew_seq(int, length_out = 3))
+xnew_data(old_data, lgl, xnew_seq(int, .length_out = 3))
 #> # A tibble: 6 × 9
 #>   lgl     int   dbl chr   fct     ord      dte        dtt                 hms   
 #>   <lgl> <int> <dbl> <chr> <fct>   <ord>    <date>     <dttm>              <time>
@@ -138,7 +138,7 @@ The user can also indicate whether only observed values should be used
 in the sequence.
 
 ``` r
-xnew_data(old_data, xnew_seq(int, length_out = 3, obs_only = TRUE))
+xnew_data(old_data, xnew_seq(int, .length_out = 3, .obs_only = TRUE))
 #> # A tibble: 3 × 9
 #>   lgl     int   dbl chr   fct     ord      dte        dtt                 hms   
 #>   <lgl> <int> <dbl> <chr> <fct>   <ord>    <date>     <dttm>              <time>
@@ -151,7 +151,7 @@ The `xobs_only()` function can be used to filter out unobserved values
 after the sequence has been generated.
 
 ``` r
-xnew_data(old_data, xobs_only(xnew_seq(int, length_out = 3)))
+xnew_data(old_data, xobs_only(xnew_seq(int, .length_out = 3)))
 #> # A tibble: 2 × 9
 #>   lgl     int   dbl chr   fct     ord      dte        dtt                 hms   
 #>   <lgl> <int> <dbl> <chr> <fct>   <ord>    <date>     <dttm>              <time>

--- a/man/new_seq.Rd
+++ b/man/new_seq.Rd
@@ -130,7 +130,7 @@ By default the sequence of values for objects of class numeric
 is 30 evenly space values across the range of the data.
 Missing values are always removed unless it's the only value
 or the object is zero length.
-The length of the sequence can be varied using the \code{length_out} argument
+The length of the sequence can be varied using the \code{.length_out} argument
 which gives the reference value when 1 and can even be 0.
 For integer objects the sequence is the unique integers.
 For character objects it's the actual values sorted by
@@ -174,29 +174,29 @@ new_seq(c(1, 4, NA))
 new_seq(NA_real_)
 # or the object is zero length
 new_seq(numeric())
-# the length of the sequence can be varied using the length_out argument
-new_seq(c(1, 4), length_out = 3)
-new_seq(c(1, 4), length_out = 2)
+# the length of the sequence can be varied using the .length_out argument
+new_seq(c(1, 4), .length_out = 3)
+new_seq(c(1, 4), .length_out = 2)
 # which gives the reference value when 1
-new_seq(c(1, 4), length_out = 1)
+new_seq(c(1, 4), .length_out = 1)
 # and can even be 0
-new_seq(c(1, 4), length_out = 0)
+new_seq(c(1, 4), .length_out = 0)
 # for integer objects the sequence is the unique integers
 new_seq(c(1L, 4L))
 new_seq(c(1L, 100L))
 # for character objects it's the actual values sorted by
 # how common they are followed by their actual value
 new_seq(c("a", "c", "c", "b", "b"))
-new_seq(c("a", "c", "c", "b", "b"), length_out = 2)
+new_seq(c("a", "c", "c", "b", "b"), .length_out = 2)
 # for factors its the factor levels in order
 new_seq(factor(c("a", "b", "c", "c"), levels = c("b", "a", "g")))
 # with the trailing levels dropped first
 new_seq(factor(c("a", "b", "c", "c"), levels = c("b", "a", "g")),
-  length_out = 2
+  .length_out = 2
 )
 # for ordered factors the intermediate levels are dropped first
 new_seq(ordered(c("a", "b", "c", "c"), levels = c("b", "a", "g")),
-  length_out = 2
+  .length_out = 2
 )
 # for Date vectors it's the unique dates
 new_seq(as.Date(c("2000-01-01", "2000-01-04")))
@@ -207,7 +207,7 @@ new_seq(as.POSIXct(c("2000-01-01 00:00:01", "2000-01-01 00:00:04"),
   tz = "PST8PDT"
 ))
 # for logical objects the longest possible sequence is `c(TRUE, FALSE)`
-new_seq(c(TRUE, TRUE, FALSE), length_out = 3)
+new_seq(c(TRUE, TRUE, FALSE), .length_out = 3)
 }
 \seealso{
 \code{\link[=new_value]{new_value()}} and \code{\link[=new_data]{new_data()}}.

--- a/man/new_seq.Rd
+++ b/man/new_seq.Rd
@@ -18,8 +18,8 @@ new_seq(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 )
 
 \method{new_seq}{logical}(
@@ -27,8 +27,8 @@ new_seq(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 )
 
 \method{new_seq}{integer}(
@@ -36,8 +36,8 @@ new_seq(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 )
 
 \method{new_seq}{double}(
@@ -45,8 +45,8 @@ new_seq(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 )
 
 \method{new_seq}{character}(
@@ -54,8 +54,8 @@ new_seq(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 )
 
 \method{new_seq}{factor}(
@@ -63,8 +63,8 @@ new_seq(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 )
 
 \method{new_seq}{ordered}(
@@ -72,8 +72,8 @@ new_seq(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 )
 
 \method{new_seq}{Date}(
@@ -81,8 +81,8 @@ new_seq(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 )
 
 \method{new_seq}{POSIXct}(
@@ -90,8 +90,8 @@ new_seq(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 )
 
 \method{new_seq}{hms}(
@@ -99,8 +99,8 @@ new_seq(
   .length_out = NULL,
   ...,
   .obs_only = NULL,
-  length_out = NULL,
-  obs_only = NULL
+  length_out = deprecated(),
+  obs_only = deprecated()
 )
 }
 \arguments{
@@ -112,9 +112,11 @@ new_seq(
 
 \item{.obs_only}{A flag specifying whether to only use observed values.}
 
-\item{length_out}{Use \code{.length_out} instead.}
+\item{length_out}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{.length_out}
+instead.}
 
-\item{obs_only}{Use \code{.obs_only} instead.}
+\item{obs_only}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{.obs_only}
+instead.}
 }
 \value{
 A vector of the same class as the object.

--- a/man/new_seq.Rd
+++ b/man/new_seq.Rd
@@ -13,34 +13,108 @@
 \alias{new_seq.hms}
 \title{Generate New Sequence}
 \usage{
-new_seq(x, length_out = NULL, ..., obs_only = NULL)
+new_seq(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+)
 
-\method{new_seq}{logical}(x, length_out = NULL, ..., obs_only = NULL)
+\method{new_seq}{logical}(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+)
 
-\method{new_seq}{integer}(x, length_out = NULL, ..., obs_only = NULL)
+\method{new_seq}{integer}(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+)
 
-\method{new_seq}{double}(x, length_out = NULL, ..., obs_only = NULL)
+\method{new_seq}{double}(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+)
 
-\method{new_seq}{character}(x, length_out = NULL, ..., obs_only = NULL)
+\method{new_seq}{character}(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+)
 
-\method{new_seq}{factor}(x, length_out = NULL, ..., obs_only = NULL)
+\method{new_seq}{factor}(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+)
 
-\method{new_seq}{ordered}(x, length_out = NULL, ..., obs_only = NULL)
+\method{new_seq}{ordered}(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+)
 
-\method{new_seq}{Date}(x, length_out = NULL, ..., obs_only = NULL)
+\method{new_seq}{Date}(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+)
 
-\method{new_seq}{POSIXct}(x, length_out = NULL, ..., obs_only = NULL)
+\method{new_seq}{POSIXct}(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+)
 
-\method{new_seq}{hms}(x, length_out = NULL, ..., obs_only = NULL)
+\method{new_seq}{hms}(
+  x,
+  .length_out = NULL,
+  ...,
+  .obs_only = NULL,
+  length_out = NULL,
+  obs_only = NULL
+)
 }
 \arguments{
 \item{x}{The object to generate the sequence from.}
 
-\item{length_out}{The maximum length of the sequence.}
+\item{.length_out}{The maximum length of the sequence.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{obs_only}{A flag specifying whether to only use observed values.}
+\item{.obs_only}{A flag specifying whether to only use observed values.}
+
+\item{length_out}{Use \code{.length_out} instead.}
+
+\item{obs_only}{Use \code{.obs_only} instead.}
 }
 \value{
 A vector of the same class as the object.

--- a/man/new_value.Rd
+++ b/man/new_value.Rd
@@ -21,8 +21,8 @@ Generate a new reference value for a vector.
 }
 \details{
 By default the reference value for double vectors is the mean,
-unless obs_only = TRUE, in which case its the median of the unique values.
-For integer vectors it's the floored mean unless obs_only = TRUE, in which case
+unless .obs_only = TRUE, in which case its the median of the unique values.
+For integer vectors it's the floored mean unless .obs_only = TRUE, in which case
 it's also the median of the unique values.
 For character vectors it's the minimum of the most common values while
 for factors it's the first level.
@@ -33,8 +33,8 @@ The factor levels and time zone are preserved.
 \examples{
 # the reference value for objects of class numeric is the mean
 new_value(c(1, 4))
-# unless obs_only = TRUE, in which case its the median of the unique values
-new_value(c(1, 4), obs_only = TRUE)
+# unless .obs_only = TRUE, in which case its the median of the unique values
+new_value(c(1, 4), .obs_only = TRUE)
 
 # for integer objects it's the floored mean
 new_value(c(1L, 4L))
@@ -49,9 +49,9 @@ new_value(factor(c("a", "b", "c", "c"), levels = c("b", "a", "g")))
 new_value(ordered(c("a", "b", "c", "c"), levels = c("b", "a", "g")))
 new_value(as.Date(c("2000-01-01", "2000-01-04")))
 new_value(hms::as_hms(c("00:00:01", "00:00:04")))
-new_value(as.POSIXct(c("2000-01-01 00:00:01", "2000-01-01 00:00:04")),
-  tzone = "PST8PDT"
-)
+new_value(as.POSIXct(c("2000-01-01 00:00:01", "2000-01-01 00:00:04"),
+  tz = "PST8PDT"
+))
 new_value(c(TRUE, FALSE, TRUE))
 
 }

--- a/man/new_value.Rd
+++ b/man/new_value.Rd
@@ -4,7 +4,7 @@
 \alias{new_value}
 \title{Generate New Reference Value}
 \usage{
-new_value(x, ..., .obs_only = NULL, obs_only = NULL)
+new_value(x, ..., .obs_only = NULL, obs_only = deprecated())
 }
 \arguments{
 \item{x}{The object to generate the reference value from.}

--- a/man/new_value.Rd
+++ b/man/new_value.Rd
@@ -4,14 +4,14 @@
 \alias{new_value}
 \title{Generate New Reference Value}
 \usage{
-new_value(x, ..., obs_only = NULL)
+new_value(x, ..., .obs_only = NULL, obs_only = NULL)
 }
 \arguments{
 \item{x}{The object to generate the reference value from.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{obs_only}{A flag specifying whether to only use observed values.}
+\item{.obs_only, obs_only}{A flag specifying whether to only use observed values.}
 }
 \value{
 A scalar of the same class as the object.

--- a/man/xnew_data.Rd
+++ b/man/xnew_data.Rd
@@ -40,13 +40,13 @@ xnew_data(data)
 xnew_data(data, annual)
 
 # The user can specify the length of a sequence.
-xnew_data(data, xnew_seq(annual, length_out = 3))
+xnew_data(data, xnew_seq(annual, .length_out = 3))
 
 # And only allow observed values.
-xnew_data(data, xnew_seq(annual, length_out = 3, obs_only = TRUE))
+xnew_data(data, xnew_seq(annual, .length_out = 3, .obs_only = TRUE))
 
 # With multiple variables all combinations are produced
-xnew_data(data, period, xnew_seq(annual, length_out = 3, obs_only = TRUE))
+xnew_data(data, period, xnew_seq(annual, .length_out = 3, .obs_only = TRUE))
 
 # To only preserve observed combinations use
 xnew_data(data, xobs_only(period, annual))

--- a/man/xnew_seq.Rd
+++ b/man/xnew_seq.Rd
@@ -27,7 +27,7 @@ data <- tibble::tibble(
   d = c("a", "b", "c")
 )
 
-xnew_data(data, a, b = new_seq(b, length_out = 3), xnew_seq(d, length_out = 2))
+xnew_data(data, a, b = new_seq(b, .length_out = 3), xnew_seq(d, .length_out = 2))
 }
 \seealso{
 \code{\link[=new_seq]{new_seq()}} and \code{\link[=xnew_data]{xnew_data()}}.

--- a/man/xobs_only.Rd
+++ b/man/xobs_only.Rd
@@ -29,7 +29,7 @@ data <- tibble::tibble(
 )
 xnew_data(data, period, annual)
 xnew_data(data, xobs_only(period, annual))
-xnew_data(data, xobs_only(period, xnew_seq(annual, length_out = 3)))
+xnew_data(data, xobs_only(period, xnew_seq(annual, .length_out = 3)))
 }
 \seealso{
 \code{\link[=xnew_data]{xnew_data()}}

--- a/tests/testthat/_snaps/deprecate-args.md
+++ b/tests/testthat/_snaps/deprecate-args.md
@@ -1,0 +1,48 @@
+# new_seq() `length_out` is deprecated but still works
+
+    Code
+      out <- new_seq(c(1, 4), length_out = 3)
+    Condition
+      Warning:
+      The `length_out` argument of `new_seq()` is deprecated as of newdata 0.1.0.
+      i Please use the `.length_out` argument instead.
+
+# new_seq() `obs_only` is deprecated but still works
+
+    Code
+      out <- new_seq(c(1L, 1L, 4L), obs_only = TRUE)
+    Condition
+      Warning:
+      The `obs_only` argument of `new_seq()` is deprecated as of newdata 0.1.0.
+      i Please use the `.obs_only` argument instead.
+
+# new_seq() deprecated arguments warn for dispatched classes (Date)
+
+    Code
+      out <- new_seq(as.Date(c("2000-01-01", "2000-01-04")), length_out = 2)
+    Condition
+      Warning:
+      The `length_out` argument of `new_seq()` is deprecated as of newdata 0.1.0.
+      i Please use the `.length_out` argument instead.
+
+# new_value() `obs_only` is deprecated but still works
+
+    Code
+      out <- new_value(c(1, 4), obs_only = TRUE)
+    Condition
+      Warning:
+      The `obs_only` argument of `new_value()` is deprecated as of newdata 0.1.0.
+      i Please use the `.obs_only` argument instead.
+
+# xnew_seq() forwards deprecated arguments with a warning
+
+    Code
+      out <- xnew_data(data, xnew_seq(a, length_out = 2))
+    Condition
+      Warning:
+      The `length_out` argument of `new_seq()` is deprecated as of newdata 0.1.0.
+      i Please use the `.length_out` argument instead.
+      Warning:
+      The `length_out` argument of `new_seq()` is deprecated as of newdata 0.1.0.
+      i Please use the `.length_out` argument instead.
+

--- a/tests/testthat/_snaps/readme.md
+++ b/tests/testthat/_snaps/readme.md
@@ -20,7 +20,7 @@
       5 FALSE     5  4.57 most  not obs a rarity 1970-01-04 1969-12-31 16:00:03 00'03"
       6 FALSE     6  4.57 most  not obs a rarity 1970-01-04 1969-12-31 16:00:03 00'03"
     Code
-      xnew_data(old_data, xnew_seq(int, length_out = 3))
+      xnew_data(old_data, xnew_seq(int, .length_out = 3))
     Output
       # A tibble: 3 x 9
         lgl     int   dbl chr   fct     ord      dte        dtt                 hms   
@@ -29,7 +29,7 @@
       2 FALSE     3  4.57 most  not obs a rarity 1970-01-04 1969-12-31 16:00:03 00'03"
       3 FALSE     6  4.57 most  not obs a rarity 1970-01-04 1969-12-31 16:00:03 00'03"
     Code
-      xnew_data(old_data, xnew_seq(int, length_out = 3, obs_only = TRUE))
+      xnew_data(old_data, xnew_seq(int, .length_out = 3, .obs_only = TRUE))
     Output
       # A tibble: 3 x 9
         lgl     int   dbl chr   fct     ord      dte        dtt                 hms   

--- a/tests/testthat/_snaps/xnew-data.md
+++ b/tests/testthat/_snaps/xnew-data.md
@@ -114,7 +114,7 @@
       10  2.74     5 a     FALSE 2023-09-29
       # i 20 more rows
     Code
-      xnew_data(data, xnew_seq(a, length_out = 12))
+      xnew_data(data, xnew_seq(a, .length_out = 12))
     Output
       # A tibble: 12 x 5
              a     b c     d     e         
@@ -132,7 +132,7 @@
       11  5.14     5 a     FALSE 2023-09-29
       12  5.5      5 a     FALSE 2023-09-29
     Code
-      xnew_data(data, xnew_seq(a, length_out = 12, obs_only = TRUE))
+      xnew_data(data, xnew_seq(a, .length_out = 12, .obs_only = TRUE))
     Output
       # A tibble: 5 x 5
             a     b c     d     e         
@@ -143,7 +143,7 @@
       4   4.5     5 a     FALSE 2023-09-29
       5   5.5     5 a     FALSE 2023-09-29
     Code
-      xnew_data(data, xnew_seq(a, length_out = 12), b)
+      xnew_data(data, xnew_seq(a, .length_out = 12), b)
     Output
       # A tibble: 60 x 5
              a     b c     d     e         
@@ -160,7 +160,7 @@
       10  1.86     7 a     FALSE 2023-09-29
       # i 50 more rows
     Code
-      xnew_data(data, b, xnew_seq(a, length_out = 12))
+      xnew_data(data, b, xnew_seq(a, .length_out = 12))
     Output
       # A tibble: 60 x 5
              a     b c     d     e         
@@ -334,7 +334,7 @@
         <fct>  <int> <fct>  <ord>  
       1 before  2005 2000   2005   
     Code
-      xnew_data(data, xnew_value(annual, obs_only = TRUE))
+      xnew_data(data, xnew_value(annual, .obs_only = TRUE))
     Output
       # A tibble: 1 x 4
         period  year annual ordered

--- a/tests/testthat/test-deprecate-args.R
+++ b/tests/testthat/test-deprecate-args.R
@@ -1,0 +1,35 @@
+test_that("new_seq() `length_out` is deprecated but still works", {
+  withr::local_options(lifecycle_verbosity = "warning")
+  expect_snapshot(out <- new_seq(c(1, 4), length_out = 3))
+  expect_identical(out, new_seq(c(1, 4), .length_out = 3))
+})
+
+test_that("new_seq() `obs_only` is deprecated but still works", {
+  withr::local_options(lifecycle_verbosity = "warning")
+  expect_snapshot(out <- new_seq(c(1L, 1L, 4L), obs_only = TRUE))
+  expect_identical(out, new_seq(c(1L, 1L, 4L), .obs_only = TRUE))
+})
+
+test_that("new_seq() deprecated arguments warn for dispatched classes (Date)", {
+  withr::local_options(lifecycle_verbosity = "warning")
+  expect_snapshot(
+    out <- new_seq(as.Date(c("2000-01-01", "2000-01-04")), length_out = 2)
+  )
+  expect_identical(
+    out,
+    new_seq(as.Date(c("2000-01-01", "2000-01-04")), .length_out = 2)
+  )
+})
+
+test_that("new_value() `obs_only` is deprecated but still works", {
+  withr::local_options(lifecycle_verbosity = "warning")
+  expect_snapshot(out <- new_value(c(1, 4), obs_only = TRUE))
+  expect_identical(out, new_value(c(1, 4), .obs_only = TRUE))
+})
+
+test_that("xnew_seq() forwards deprecated arguments with a warning", {
+  withr::local_options(lifecycle_verbosity = "warning")
+  data <- tibble::tibble(a = c(1L, 3L, 4L))
+  expect_snapshot(out <- xnew_data(data, xnew_seq(a, length_out = 2)))
+  expect_identical(out, xnew_data(data, xnew_seq(a, .length_out = 2)))
+})

--- a/tests/testthat/test-new-seq.R
+++ b/tests/testthat/test-new-seq.R
@@ -22,8 +22,11 @@ test_that("new_seq logical", {
   expect_identical(new_seq(c(FALSE, FALSE, TRUE, NA)), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, TRUE, FALSE, NA)), c(FALSE, TRUE))
   # length_out not count
-  expect_error(new_seq(TRUE, length_out = -1), "`length_out` must be a count")
-  expect_error(new_seq(TRUE, length_out = 0.5), "`length_out` must be a count")
+  expect_error(new_seq(TRUE, .length_out = -1), "`.length_out` must be a count")
+  expect_error(
+    new_seq(TRUE, .length_out = 0.5),
+    "`.length_out` must be a count"
+  )
   # matrices and arrays
   expect_identical(new_seq(matrix(TRUE)), c(FALSE, TRUE))
   expect_identical(new_seq(array(TRUE)), c(FALSE, TRUE))
@@ -34,13 +37,13 @@ test_that("new_seq logical", {
   expect_identical(new_seq(logical()), c(FALSE, TRUE))
   # missing value
   expect_identical(new_seq(NA), c(FALSE, TRUE))
-  expect_identical(new_seq(NA, obs_only = TRUE), NA)
+  expect_identical(new_seq(NA, .obs_only = TRUE), NA)
   # single value
   expect_identical(new_seq(TRUE), c(FALSE, TRUE))
   expect_identical(new_seq(FALSE), c(FALSE, TRUE))
   expect_identical(new_seq(FALSE), c(FALSE, TRUE))
-  expect_identical(new_seq(TRUE, obs_only = TRUE), TRUE)
-  expect_identical(new_seq(FALSE, obs_only = TRUE), FALSE)
+  expect_identical(new_seq(TRUE, .obs_only = TRUE), TRUE)
+  expect_identical(new_seq(FALSE, .obs_only = TRUE), FALSE)
   # multiple value
   expect_identical(new_seq(c(FALSE, TRUE)), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, FALSE)), c(FALSE, TRUE))
@@ -48,16 +51,16 @@ test_that("new_seq logical", {
   expect_identical(new_seq(c(FALSE, FALSE)), c(FALSE, TRUE))
   expect_identical(new_seq(c(FALSE, FALSE, TRUE)), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, TRUE, FALSE)), c(FALSE, TRUE))
-  expect_identical(new_seq(c(FALSE, TRUE), obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, FALSE), obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE), obs_only = TRUE), TRUE)
-  expect_identical(new_seq(c(FALSE, FALSE), obs_only = TRUE), FALSE)
+  expect_identical(new_seq(c(FALSE, TRUE), .obs_only = TRUE), c(FALSE, TRUE))
+  expect_identical(new_seq(c(TRUE, FALSE), .obs_only = TRUE), c(FALSE, TRUE))
+  expect_identical(new_seq(c(TRUE, TRUE), .obs_only = TRUE), TRUE)
+  expect_identical(new_seq(c(FALSE, FALSE), .obs_only = TRUE), FALSE)
   expect_identical(
-    new_seq(c(FALSE, FALSE, TRUE), obs_only = TRUE),
+    new_seq(c(FALSE, FALSE, TRUE), .obs_only = TRUE),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(TRUE, TRUE, FALSE), obs_only = TRUE),
+    new_seq(c(TRUE, TRUE, FALSE), .obs_only = TRUE),
     c(FALSE, TRUE)
   )
   # multiple value with missing
@@ -67,159 +70,168 @@ test_that("new_seq logical", {
   expect_identical(new_seq(c(FALSE, FALSE, NA)), c(FALSE, TRUE))
   expect_identical(new_seq(c(FALSE, FALSE, TRUE, NA)), c(FALSE, TRUE))
   expect_identical(new_seq(c(TRUE, TRUE, FALSE, NA)), c(FALSE, TRUE))
-  expect_identical(new_seq(c(FALSE, TRUE, NA), obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, FALSE, NA), obs_only = TRUE), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE, NA), obs_only = TRUE), TRUE)
-  expect_identical(new_seq(c(FALSE, FALSE, NA), obs_only = TRUE), FALSE)
   expect_identical(
-    new_seq(c(FALSE, FALSE, TRUE, NA), obs_only = TRUE),
+    new_seq(c(FALSE, TRUE, NA), .obs_only = TRUE),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(TRUE, TRUE, FALSE, NA), obs_only = TRUE),
+    new_seq(c(TRUE, FALSE, NA), .obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(new_seq(c(TRUE, TRUE, NA), .obs_only = TRUE), TRUE)
+  expect_identical(new_seq(c(FALSE, FALSE, NA), .obs_only = TRUE), FALSE)
+  expect_identical(
+    new_seq(c(FALSE, FALSE, TRUE, NA), .obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE, NA), .obs_only = TRUE),
     c(FALSE, TRUE)
   )
   # length_out not count
-  expect_error(new_seq(TRUE, length_out = -1), "`length_out` must be a count")
-  expect_error(new_seq(TRUE, length_out = 0.5), "`length_out` must be a count")
+  expect_error(new_seq(TRUE, .length_out = -1), "`.length_out` must be a count")
   expect_error(
-    new_seq(TRUE, length_out = -1, obs_only = TRUE),
-    "`length_out` must be a count"
+    new_seq(TRUE, .length_out = 0.5),
+    "`.length_out` must be a count"
   )
   expect_error(
-    new_seq(TRUE, length_out = 0.5, obs_only = TRUE),
-    "`length_out` must be a count"
+    new_seq(TRUE, .length_out = -1, .obs_only = TRUE),
+    "`.length_out` must be a count"
+  )
+  expect_error(
+    new_seq(TRUE, .length_out = 0.5, .obs_only = TRUE),
+    "`.length_out` must be a count"
   )
   # length_out is 0
-  expect_identical(new_seq(logical(), length_out = 0), logical())
-  expect_identical(new_seq(NA, length_out = 0), logical())
-  expect_identical(new_seq(TRUE, length_out = 0), logical())
+  expect_identical(new_seq(logical(), .length_out = 0), logical())
+  expect_identical(new_seq(NA, .length_out = 0), logical())
+  expect_identical(new_seq(TRUE, .length_out = 0), logical())
   expect_identical(
-    new_seq(logical(), length_out = 0, obs_only = TRUE),
+    new_seq(logical(), .length_out = 0, .obs_only = TRUE),
     logical()
   )
-  expect_identical(new_seq(NA, length_out = 0, obs_only = TRUE), logical())
-  expect_identical(new_seq(TRUE, length_out = 0, obs_only = TRUE), logical())
-  # length_out = 1
-  expect_identical(new_seq(c(FALSE, TRUE), length_out = 1), FALSE)
-  expect_identical(new_seq(c(TRUE, FALSE), length_out = 1), FALSE)
-  expect_identical(new_seq(c(TRUE, TRUE), length_out = 1), FALSE)
-  expect_identical(new_seq(c(FALSE, FALSE), length_out = 1), FALSE)
-  expect_identical(new_seq(c(FALSE, FALSE, TRUE), length_out = 1), FALSE)
-  expect_identical(new_seq(c(TRUE, TRUE, FALSE), length_out = 1), FALSE)
+  expect_identical(new_seq(NA, .length_out = 0, .obs_only = TRUE), logical())
+  expect_identical(new_seq(TRUE, .length_out = 0, .obs_only = TRUE), logical())
+  # .length_out = 1
+  expect_identical(new_seq(c(FALSE, TRUE), .length_out = 1), FALSE)
+  expect_identical(new_seq(c(TRUE, FALSE), .length_out = 1), FALSE)
+  expect_identical(new_seq(c(TRUE, TRUE), .length_out = 1), FALSE)
+  expect_identical(new_seq(c(FALSE, FALSE), .length_out = 1), FALSE)
+  expect_identical(new_seq(c(FALSE, FALSE, TRUE), .length_out = 1), FALSE)
+  expect_identical(new_seq(c(TRUE, TRUE, FALSE), .length_out = 1), FALSE)
   expect_identical(
-    new_seq(c(FALSE, TRUE), length_out = 1, obs_only = TRUE),
+    new_seq(c(FALSE, TRUE), .length_out = 1, .obs_only = TRUE),
     FALSE
   )
   expect_identical(
-    new_seq(c(TRUE, FALSE), length_out = 1, obs_only = TRUE),
+    new_seq(c(TRUE, FALSE), .length_out = 1, .obs_only = TRUE),
     FALSE
   )
   expect_identical(
-    new_seq(c(TRUE, TRUE), length_out = 1, obs_only = TRUE),
+    new_seq(c(TRUE, TRUE), .length_out = 1, .obs_only = TRUE),
     TRUE
   )
   expect_identical(
-    new_seq(c(FALSE, FALSE), length_out = 1, obs_only = TRUE),
+    new_seq(c(FALSE, FALSE), .length_out = 1, .obs_only = TRUE),
     FALSE
   )
   expect_identical(
-    new_seq(c(FALSE, FALSE, TRUE), length_out = 1, obs_only = TRUE),
+    new_seq(c(FALSE, FALSE, TRUE), .length_out = 1, .obs_only = TRUE),
     FALSE
   )
   expect_identical(
-    new_seq(c(TRUE, TRUE, FALSE), length_out = 1, obs_only = TRUE),
+    new_seq(c(TRUE, TRUE, FALSE), .length_out = 1, .obs_only = TRUE),
     FALSE
   )
-  # length_out = 2
-  expect_identical(new_seq(c(FALSE, TRUE), length_out = 2), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, FALSE), length_out = 2), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE), length_out = 2), c(FALSE, TRUE))
-  expect_identical(new_seq(c(FALSE, FALSE), length_out = 2), c(FALSE, TRUE))
+  # .length_out = 2
+  expect_identical(new_seq(c(FALSE, TRUE), .length_out = 2), c(FALSE, TRUE))
+  expect_identical(new_seq(c(TRUE, FALSE), .length_out = 2), c(FALSE, TRUE))
+  expect_identical(new_seq(c(TRUE, TRUE), .length_out = 2), c(FALSE, TRUE))
+  expect_identical(new_seq(c(FALSE, FALSE), .length_out = 2), c(FALSE, TRUE))
   expect_identical(
-    new_seq(c(FALSE, FALSE, TRUE), length_out = 2),
+    new_seq(c(FALSE, FALSE, TRUE), .length_out = 2),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(TRUE, TRUE, FALSE), length_out = 2),
+    new_seq(c(TRUE, TRUE, FALSE), .length_out = 2),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(FALSE, TRUE), length_out = 2, obs_only = TRUE),
+    new_seq(c(FALSE, TRUE), .length_out = 2, .obs_only = TRUE),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(TRUE, FALSE), length_out = 2, obs_only = TRUE),
+    new_seq(c(TRUE, FALSE), .length_out = 2, .obs_only = TRUE),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(TRUE, TRUE), length_out = 2, obs_only = TRUE),
+    new_seq(c(TRUE, TRUE), .length_out = 2, .obs_only = TRUE),
     TRUE
   )
   expect_identical(
-    new_seq(c(FALSE, FALSE), length_out = 2, obs_only = TRUE),
+    new_seq(c(FALSE, FALSE), .length_out = 2, .obs_only = TRUE),
     FALSE
   )
   expect_identical(
-    new_seq(c(FALSE, FALSE, TRUE), length_out = 2, obs_only = TRUE),
+    new_seq(c(FALSE, FALSE, TRUE), .length_out = 2, .obs_only = TRUE),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(TRUE, TRUE, FALSE), length_out = 2, obs_only = TRUE),
+    new_seq(c(TRUE, TRUE, FALSE), .length_out = 2, .obs_only = TRUE),
     c(FALSE, TRUE)
   )
-  # length_out = 3
-  expect_identical(new_seq(c(FALSE, TRUE), length_out = 3), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, FALSE), length_out = 3), c(FALSE, TRUE))
-  expect_identical(new_seq(c(TRUE, TRUE), length_out = 3), c(FALSE, TRUE))
-  expect_identical(new_seq(c(FALSE, FALSE), length_out = 3), c(FALSE, TRUE))
+  # .length_out = 3
+  expect_identical(new_seq(c(FALSE, TRUE), .length_out = 3), c(FALSE, TRUE))
+  expect_identical(new_seq(c(TRUE, FALSE), .length_out = 3), c(FALSE, TRUE))
+  expect_identical(new_seq(c(TRUE, TRUE), .length_out = 3), c(FALSE, TRUE))
+  expect_identical(new_seq(c(FALSE, FALSE), .length_out = 3), c(FALSE, TRUE))
   expect_identical(
-    new_seq(c(FALSE, FALSE, TRUE), length_out = 3),
-    c(FALSE, TRUE)
-  )
-  expect_identical(
-    new_seq(c(TRUE, TRUE, FALSE), length_out = 3),
+    new_seq(c(FALSE, FALSE, TRUE), .length_out = 3),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(FALSE, TRUE), length_out = 3, obs_only = TRUE),
+    new_seq(c(TRUE, TRUE, FALSE), .length_out = 3),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(TRUE, FALSE), length_out = 3, obs_only = TRUE),
+    new_seq(c(FALSE, TRUE), .length_out = 3, .obs_only = TRUE),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(TRUE, TRUE), length_out = 3, obs_only = TRUE),
+    new_seq(c(TRUE, FALSE), .length_out = 3, .obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE), .length_out = 3, .obs_only = TRUE),
     TRUE
   )
   expect_identical(
-    new_seq(c(FALSE, FALSE), length_out = 3, obs_only = TRUE),
+    new_seq(c(FALSE, FALSE), .length_out = 3, .obs_only = TRUE),
     FALSE
   )
   expect_identical(
-    new_seq(c(FALSE, FALSE, TRUE), length_out = 3, obs_only = TRUE),
+    new_seq(c(FALSE, FALSE, TRUE), .length_out = 3, .obs_only = TRUE),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(TRUE, TRUE, FALSE), length_out = 3, obs_only = TRUE),
+    new_seq(c(TRUE, TRUE, FALSE), .length_out = 3, .obs_only = TRUE),
     c(FALSE, TRUE)
   )
-  # length_out = Inf
+  # .length_out = Inf
   expect_identical(
-    new_seq(c(FALSE, FALSE, TRUE), length_out = Inf),
-    c(FALSE, TRUE)
-  )
-  expect_identical(
-    new_seq(c(TRUE, TRUE, FALSE), length_out = Inf),
+    new_seq(c(FALSE, FALSE, TRUE), .length_out = Inf),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(FALSE, FALSE, TRUE), length_out = Inf, obs_only = TRUE),
+    new_seq(c(TRUE, TRUE, FALSE), .length_out = Inf),
     c(FALSE, TRUE)
   )
   expect_identical(
-    new_seq(c(TRUE, TRUE, FALSE), length_out = Inf, obs_only = TRUE),
+    new_seq(c(FALSE, FALSE, TRUE), .length_out = Inf, .obs_only = TRUE),
+    c(FALSE, TRUE)
+  )
+  expect_identical(
+    new_seq(c(TRUE, TRUE, FALSE), .length_out = Inf, .obs_only = TRUE),
     c(FALSE, TRUE)
   )
   # matrices and arrays
@@ -231,15 +243,15 @@ test_that("new_seq logical", {
 test_that("new_seq integer", {
   # zero length
   expect_identical(new_seq(integer(0)), NA_integer_)
-  expect_identical(new_seq(integer(0), obs_only = TRUE), NA_integer_)
+  expect_identical(new_seq(integer(0), .obs_only = TRUE), NA_integer_)
   # missing value
   expect_identical(new_seq(NA_integer_), NA_integer_)
-  expect_identical(new_seq(NA_integer_, obs_only = TRUE), NA_integer_)
+  expect_identical(new_seq(NA_integer_, .obs_only = TRUE), NA_integer_)
   # single value
   expect_identical(new_seq(1L), 1L)
   expect_identical(new_seq(0L), 0L)
-  expect_identical(new_seq(1L, obs_only = TRUE), 1L)
-  expect_identical(new_seq(0L, obs_only = TRUE), 0L)
+  expect_identical(new_seq(1L, .obs_only = TRUE), 1L)
+  expect_identical(new_seq(0L, .obs_only = TRUE), 0L)
   # multiple value
   expect_identical(new_seq(c(0L, 1L)), c(0L, 1L))
   expect_identical(new_seq(c(1L, 0L)), c(0L, 1L))
@@ -283,14 +295,14 @@ test_that("new_seq integer", {
       100L
     )
   )
-  expect_identical(new_seq(c(0L, 1L), obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 0L), obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 1L), obs_only = TRUE), 1L)
-  expect_identical(new_seq(c(0L, 0L), obs_only = TRUE), 0L)
-  expect_identical(new_seq(c(0L, 0L, 1L), obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 1L, 0L), obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(10L, 1L), obs_only = TRUE), c(1L, 10L))
-  expect_identical(new_seq(c(100L, 1L), obs_only = TRUE), c(1L, 100L))
+  expect_identical(new_seq(c(0L, 1L), .obs_only = TRUE), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 0L), .obs_only = TRUE), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 1L), .obs_only = TRUE), 1L)
+  expect_identical(new_seq(c(0L, 0L), .obs_only = TRUE), 0L)
+  expect_identical(new_seq(c(0L, 0L, 1L), .obs_only = TRUE), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 1L, 0L), .obs_only = TRUE), c(0L, 1L))
+  expect_identical(new_seq(c(10L, 1L), .obs_only = TRUE), c(1L, 10L))
+  expect_identical(new_seq(c(100L, 1L), .obs_only = TRUE), c(1L, 100L))
   # multiple value with missing
   expect_identical(new_seq(c(0L, 1L, NA)), c(0L, 1L))
   expect_identical(new_seq(c(1L, 0L, NA)), c(0L, 1L))
@@ -334,134 +346,140 @@ test_that("new_seq integer", {
       100L
     )
   )
-  expect_identical(new_seq(c(0L, 1L, NA), obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 0L, NA), obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 1L, NA), obs_only = TRUE), 1L)
-  expect_identical(new_seq(c(0L, 0L, NA), obs_only = TRUE), 0L)
-  expect_identical(new_seq(c(0L, 0L, 1L, NA), obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 1L, 0L, NA), obs_only = TRUE), c(0L, 1L))
-  expect_identical(new_seq(c(10L, 1L, NA), obs_only = TRUE), c(1L, 10L))
-  expect_identical(new_seq(c(100L, 1L, NA), obs_only = TRUE), c(1L, 100L))
+  expect_identical(new_seq(c(0L, 1L, NA), .obs_only = TRUE), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 0L, NA), .obs_only = TRUE), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 1L, NA), .obs_only = TRUE), 1L)
+  expect_identical(new_seq(c(0L, 0L, NA), .obs_only = TRUE), 0L)
+  expect_identical(new_seq(c(0L, 0L, 1L, NA), .obs_only = TRUE), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 1L, 0L, NA), .obs_only = TRUE), c(0L, 1L))
+  expect_identical(new_seq(c(10L, 1L, NA), .obs_only = TRUE), c(1L, 10L))
+  expect_identical(new_seq(c(100L, 1L, NA), .obs_only = TRUE), c(1L, 100L))
   # length_out not count
-  expect_error(new_seq(1L, length_out = -1), "`length_out` must be a count")
-  expect_error(new_seq(1L, length_out = 0.5), "`length_out` must be a count")
+  expect_error(new_seq(1L, .length_out = -1), "`.length_out` must be a count")
+  expect_error(new_seq(1L, .length_out = 0.5), "`.length_out` must be a count")
   expect_error(
-    new_seq(1L, length_out = -1, obs_only = TRUE),
-    "`length_out` must be a count"
+    new_seq(1L, .length_out = -1, .obs_only = TRUE),
+    "`.length_out` must be a count"
   )
   expect_error(
-    new_seq(1L, length_out = 0.5, obs_only = TRUE),
-    "`length_out` must be a count"
+    new_seq(1L, .length_out = 0.5, .obs_only = TRUE),
+    "`.length_out` must be a count"
   )
   # length_out is 0
-  expect_identical(new_seq(integer(), length_out = 0), integer())
-  expect_identical(new_seq(NA_integer_, length_out = 0), integer())
-  expect_identical(new_seq(1L, length_out = 0), integer())
+  expect_identical(new_seq(integer(), .length_out = 0), integer())
+  expect_identical(new_seq(NA_integer_, .length_out = 0), integer())
+  expect_identical(new_seq(1L, .length_out = 0), integer())
   expect_identical(
-    new_seq(integer(), length_out = 0, obs_only = TRUE),
+    new_seq(integer(), .length_out = 0, .obs_only = TRUE),
     integer()
   )
   expect_identical(
-    new_seq(NA_integer_, length_out = 0, obs_only = TRUE),
+    new_seq(NA_integer_, .length_out = 0, .obs_only = TRUE),
     integer()
   )
-  expect_identical(new_seq(1L, length_out = 0, obs_only = TRUE), integer())
-  # length_out = 1
-  expect_identical(new_seq(c(0L, 1L), length_out = 1), 0L)
-  expect_identical(new_seq(c(1L, 0L), length_out = 1), 0L)
-  expect_identical(new_seq(c(1L, 1L), length_out = 1), 1L)
-  expect_identical(new_seq(c(0L, 0L), length_out = 1), 0L)
-  expect_identical(new_seq(c(0L, 0L, 1L), length_out = 1), 0L)
-  expect_identical(new_seq(c(1L, 1L, 0L), length_out = 1), 0L)
-  expect_identical(new_seq(c(10L, 1L), length_out = 1), 5L)
-  expect_identical(new_seq(c(100L, 1L), length_out = 1), 50L)
-  expect_identical(new_seq(c(0L, 1L), length_out = 1, obs_only = TRUE), 0L)
-  expect_identical(new_seq(c(1L, 0L), length_out = 1, obs_only = TRUE), 0L)
-  expect_identical(new_seq(c(1L, 1L), length_out = 1, obs_only = TRUE), 1L)
-  expect_identical(new_seq(c(0L, 0L), length_out = 1, obs_only = TRUE), 0L)
-  expect_identical(new_seq(c(0L, 0L, 1L), length_out = 1, obs_only = TRUE), 0L)
-  expect_identical(new_seq(c(1L, 1L, 0L), length_out = 1, obs_only = TRUE), 0L)
-  expect_identical(new_seq(c(10L, 1L), length_out = 1, obs_only = TRUE), 1L)
-  expect_identical(new_seq(c(100L, 1L), length_out = 1, obs_only = TRUE), 1L)
-  # length_out = 2
-  expect_identical(new_seq(c(0L, 1L), length_out = 2), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 0L), length_out = 2), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 1L), length_out = 2), 1L)
-  expect_identical(new_seq(c(0L, 0L), length_out = 2), 0L)
-  expect_identical(new_seq(c(0L, 0L, 1L), length_out = 2), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 1L, 0L), length_out = 2), c(0L, 1L))
-  expect_identical(new_seq(c(10L, 1L), length_out = 2), c(1L, 10L))
-  expect_identical(new_seq(c(100L, 1L), length_out = 2), c(1L, 100L))
+  expect_identical(new_seq(1L, .length_out = 0, .obs_only = TRUE), integer())
+  # .length_out = 1
+  expect_identical(new_seq(c(0L, 1L), .length_out = 1), 0L)
+  expect_identical(new_seq(c(1L, 0L), .length_out = 1), 0L)
+  expect_identical(new_seq(c(1L, 1L), .length_out = 1), 1L)
+  expect_identical(new_seq(c(0L, 0L), .length_out = 1), 0L)
+  expect_identical(new_seq(c(0L, 0L, 1L), .length_out = 1), 0L)
+  expect_identical(new_seq(c(1L, 1L, 0L), .length_out = 1), 0L)
+  expect_identical(new_seq(c(10L, 1L), .length_out = 1), 5L)
+  expect_identical(new_seq(c(100L, 1L), .length_out = 1), 50L)
+  expect_identical(new_seq(c(0L, 1L), .length_out = 1, .obs_only = TRUE), 0L)
+  expect_identical(new_seq(c(1L, 0L), .length_out = 1, .obs_only = TRUE), 0L)
+  expect_identical(new_seq(c(1L, 1L), .length_out = 1, .obs_only = TRUE), 1L)
+  expect_identical(new_seq(c(0L, 0L), .length_out = 1, .obs_only = TRUE), 0L)
   expect_identical(
-    new_seq(c(0L, 1L), length_out = 2, obs_only = TRUE),
+    new_seq(c(0L, 0L, 1L), .length_out = 1, .obs_only = TRUE),
+    0L
+  )
+  expect_identical(
+    new_seq(c(1L, 1L, 0L), .length_out = 1, .obs_only = TRUE),
+    0L
+  )
+  expect_identical(new_seq(c(10L, 1L), .length_out = 1, .obs_only = TRUE), 1L)
+  expect_identical(new_seq(c(100L, 1L), .length_out = 1, .obs_only = TRUE), 1L)
+  # .length_out = 2
+  expect_identical(new_seq(c(0L, 1L), .length_out = 2), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 0L), .length_out = 2), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 1L), .length_out = 2), 1L)
+  expect_identical(new_seq(c(0L, 0L), .length_out = 2), 0L)
+  expect_identical(new_seq(c(0L, 0L, 1L), .length_out = 2), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 1L, 0L), .length_out = 2), c(0L, 1L))
+  expect_identical(new_seq(c(10L, 1L), .length_out = 2), c(1L, 10L))
+  expect_identical(new_seq(c(100L, 1L), .length_out = 2), c(1L, 100L))
+  expect_identical(
+    new_seq(c(0L, 1L), .length_out = 2, .obs_only = TRUE),
     c(0L, 1L)
   )
   expect_identical(
-    new_seq(c(1L, 0L), length_out = 2, obs_only = TRUE),
+    new_seq(c(1L, 0L), .length_out = 2, .obs_only = TRUE),
     c(0L, 1L)
   )
-  expect_identical(new_seq(c(1L, 1L), length_out = 2, obs_only = TRUE), 1L)
-  expect_identical(new_seq(c(0L, 0L), length_out = 2, obs_only = TRUE), 0L)
+  expect_identical(new_seq(c(1L, 1L), .length_out = 2, .obs_only = TRUE), 1L)
+  expect_identical(new_seq(c(0L, 0L), .length_out = 2, .obs_only = TRUE), 0L)
   expect_identical(
-    new_seq(c(0L, 0L, 1L), length_out = 2, obs_only = TRUE),
-    c(0L, 1L)
-  )
-  expect_identical(
-    new_seq(c(1L, 1L, 0L), length_out = 2, obs_only = TRUE),
+    new_seq(c(0L, 0L, 1L), .length_out = 2, .obs_only = TRUE),
     c(0L, 1L)
   )
   expect_identical(
-    new_seq(c(10L, 1L), length_out = 2, obs_only = TRUE),
+    new_seq(c(1L, 1L, 0L), .length_out = 2, .obs_only = TRUE),
+    c(0L, 1L)
+  )
+  expect_identical(
+    new_seq(c(10L, 1L), .length_out = 2, .obs_only = TRUE),
     c(1L, 10L)
   )
   expect_identical(
-    new_seq(c(100L, 1L), length_out = 2, obs_only = TRUE),
+    new_seq(c(100L, 1L), .length_out = 2, .obs_only = TRUE),
     c(1L, 100L)
   )
-  # length_out = 3
-  expect_identical(new_seq(c(0L, 1L), length_out = 3), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 0L), length_out = 3), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 1L), length_out = 3), 1L)
-  expect_identical(new_seq(c(0L, 0L), length_out = 3), 0L)
-  expect_identical(new_seq(c(0L, 0L, 1L), length_out = 3), c(0L, 1L))
-  expect_identical(new_seq(c(1L, 1L, 0L), length_out = 3), c(0L, 1L))
-  expect_identical(new_seq(c(10L, 1L), length_out = 3), c(1L, 5L, 10L))
-  expect_identical(new_seq(c(100L, 1L), length_out = 3), c(1L, 50L, 100L))
+  # .length_out = 3
+  expect_identical(new_seq(c(0L, 1L), .length_out = 3), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 0L), .length_out = 3), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 1L), .length_out = 3), 1L)
+  expect_identical(new_seq(c(0L, 0L), .length_out = 3), 0L)
+  expect_identical(new_seq(c(0L, 0L, 1L), .length_out = 3), c(0L, 1L))
+  expect_identical(new_seq(c(1L, 1L, 0L), .length_out = 3), c(0L, 1L))
+  expect_identical(new_seq(c(10L, 1L), .length_out = 3), c(1L, 5L, 10L))
+  expect_identical(new_seq(c(100L, 1L), .length_out = 3), c(1L, 50L, 100L))
   expect_identical(
-    new_seq(c(0L, 1L), length_out = 3, obs_only = TRUE),
+    new_seq(c(0L, 1L), .length_out = 3, .obs_only = TRUE),
     c(0L, 1L)
   )
   expect_identical(
-    new_seq(c(1L, 0L), length_out = 3, obs_only = TRUE),
+    new_seq(c(1L, 0L), .length_out = 3, .obs_only = TRUE),
     c(0L, 1L)
   )
-  expect_identical(new_seq(c(1L, 1L), length_out = 3, obs_only = TRUE), 1L)
-  expect_identical(new_seq(c(0L, 0L), length_out = 3, obs_only = TRUE), 0L)
+  expect_identical(new_seq(c(1L, 1L), .length_out = 3, .obs_only = TRUE), 1L)
+  expect_identical(new_seq(c(0L, 0L), .length_out = 3, .obs_only = TRUE), 0L)
   expect_identical(
-    new_seq(c(0L, 0L, 1L), length_out = 3, obs_only = TRUE),
-    c(0L, 1L)
-  )
-  expect_identical(
-    new_seq(c(1L, 1L, 0L), length_out = 3, obs_only = TRUE),
+    new_seq(c(0L, 0L, 1L), .length_out = 3, .obs_only = TRUE),
     c(0L, 1L)
   )
   expect_identical(
-    new_seq(c(10L, 1L), length_out = 3, obs_only = TRUE),
+    new_seq(c(1L, 1L, 0L), .length_out = 3, .obs_only = TRUE),
+    c(0L, 1L)
+  )
+  expect_identical(
+    new_seq(c(10L, 1L), .length_out = 3, .obs_only = TRUE),
     c(1L, 10L)
   )
   expect_identical(
-    new_seq(c(100L, 1L), length_out = 3, obs_only = TRUE),
+    new_seq(c(100L, 1L), .length_out = 3, .obs_only = TRUE),
     c(1L, 100L)
   )
-  # length_out = Inf
-  expect_identical(new_seq(c(10L, 1L), length_out = Inf), 1:10)
-  expect_identical(new_seq(c(100L, 1L), length_out = Inf), 1:100)
+  # .length_out = Inf
+  expect_identical(new_seq(c(10L, 1L), .length_out = Inf), 1:10)
+  expect_identical(new_seq(c(100L, 1L), .length_out = Inf), 1:100)
   expect_identical(
-    new_seq(c(10L, 1L), length_out = Inf, obs_only = TRUE),
+    new_seq(c(10L, 1L), .length_out = Inf, .obs_only = TRUE),
     c(1L, 10L)
   )
   expect_identical(
-    new_seq(c(100L, 1L), length_out = Inf, obs_only = TRUE),
+    new_seq(c(100L, 1L), .length_out = Inf, .obs_only = TRUE),
     c(1L, 100L)
   )
   # matrices and arrays
@@ -472,19 +490,19 @@ test_that("new_seq integer", {
 test_that("new_seq numeric", {
   # zero length
   expect_identical(new_seq(numeric(0)), NA_real_)
-  expect_identical(new_seq(numeric(0), obs_only = TRUE), NA_real_)
+  expect_identical(new_seq(numeric(0), .obs_only = TRUE), NA_real_)
   # missing value
   expect_identical(new_seq(NA_real_), NA_real_)
-  expect_identical(new_seq(NA_real_, obs_only = TRUE), NA_real_)
+  expect_identical(new_seq(NA_real_, .obs_only = TRUE), NA_real_)
   # single value
   expect_identical(new_seq(1), 1)
   expect_identical(new_seq(0), 0)
   expect_identical(new_seq(1.1), 1.1)
   expect_identical(new_seq(-1), -1)
-  expect_identical(new_seq(1, obs_only = TRUE), 1)
-  expect_identical(new_seq(0, obs_only = TRUE), 0)
-  expect_identical(new_seq(1.1, obs_only = TRUE), 1.1)
-  expect_identical(new_seq(-1, obs_only = TRUE), -1)
+  expect_identical(new_seq(1, .obs_only = TRUE), 1)
+  expect_identical(new_seq(0, .obs_only = TRUE), 0)
+  expect_identical(new_seq(1.1, .obs_only = TRUE), 1.1)
+  expect_identical(new_seq(-1, .obs_only = TRUE), -1)
   # multiple value
   x0to1 <- seq(0, 1, length.out = 30)
   expect_identical(new_seq(c(0, 1)), x0to1)
@@ -495,14 +513,14 @@ test_that("new_seq numeric", {
   expect_identical(new_seq(c(1, 1, 0)), x0to1)
   expect_equal(new_seq(c(10, 0)), x0to1 * 10)
   expect_equal(new_seq(c(100, 0)), x0to1 * 100)
-  expect_identical(new_seq(c(0, 1), obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 0), obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 1), obs_only = TRUE), 1)
-  expect_identical(new_seq(c(0, 0), obs_only = TRUE), 0)
-  expect_identical(new_seq(c(0, 0, 1), obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 1, 0), obs_only = TRUE), c(0, 1))
-  expect_equal(new_seq(c(10, 0), obs_only = TRUE), c(0, 10))
-  expect_equal(new_seq(c(100, 0), obs_only = TRUE), c(0, 100))
+  expect_identical(new_seq(c(0, 1), .obs_only = TRUE), c(0, 1))
+  expect_identical(new_seq(c(1, 0), .obs_only = TRUE), c(0, 1))
+  expect_identical(new_seq(c(1, 1), .obs_only = TRUE), 1)
+  expect_identical(new_seq(c(0, 0), .obs_only = TRUE), 0)
+  expect_identical(new_seq(c(0, 0, 1), .obs_only = TRUE), c(0, 1))
+  expect_identical(new_seq(c(1, 1, 0), .obs_only = TRUE), c(0, 1))
+  expect_equal(new_seq(c(10, 0), .obs_only = TRUE), c(0, 10))
+  expect_equal(new_seq(c(100, 0), .obs_only = TRUE), c(0, 100))
   # multiple value with missing
   x0to1 <- seq(0, 1, length.out = 30)
   expect_identical(new_seq(c(0, 1, NA)), x0to1)
@@ -513,110 +531,122 @@ test_that("new_seq numeric", {
   expect_identical(new_seq(c(1, 1, 0, NA)), x0to1)
   expect_equal(new_seq(c(10, 0, NA)), x0to1 * 10)
   expect_equal(new_seq(c(100, 0, NA)), x0to1 * 100)
-  expect_identical(new_seq(c(0, 1, NA), obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 0, NA), obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 1, NA), obs_only = TRUE), 1)
-  expect_identical(new_seq(c(0, 0, NA), obs_only = TRUE), 0)
-  expect_identical(new_seq(c(0, 0, 1, NA), obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 1, 0, NA), obs_only = TRUE), c(0, 1))
-  expect_equal(new_seq(c(10, 0, NA), obs_only = TRUE), c(0, 10))
-  expect_equal(new_seq(c(100, 0, NA), obs_only = TRUE), c(0, 100))
+  expect_identical(new_seq(c(0, 1, NA), .obs_only = TRUE), c(0, 1))
+  expect_identical(new_seq(c(1, 0, NA), .obs_only = TRUE), c(0, 1))
+  expect_identical(new_seq(c(1, 1, NA), .obs_only = TRUE), 1)
+  expect_identical(new_seq(c(0, 0, NA), .obs_only = TRUE), 0)
+  expect_identical(new_seq(c(0, 0, 1, NA), .obs_only = TRUE), c(0, 1))
+  expect_identical(new_seq(c(1, 1, 0, NA), .obs_only = TRUE), c(0, 1))
+  expect_equal(new_seq(c(10, 0, NA), .obs_only = TRUE), c(0, 10))
+  expect_equal(new_seq(c(100, 0, NA), .obs_only = TRUE), c(0, 100))
   # length_out not count
-  expect_error(new_seq(1, length_out = -1), "`length_out` must be a count")
-  expect_error(new_seq(1, length_out = 0.5), "`length_out` must be a count")
+  expect_error(new_seq(1, .length_out = -1), "`.length_out` must be a count")
+  expect_error(new_seq(1, .length_out = 0.5), "`.length_out` must be a count")
   expect_error(
-    new_seq(1, length_out = -1, obs_only = TRUE),
-    "`length_out` must be a count"
+    new_seq(1, .length_out = -1, .obs_only = TRUE),
+    "`.length_out` must be a count"
   )
   expect_error(
-    new_seq(1, length_out = 0.5, obs_only = TRUE),
-    "`length_out` must be a count"
+    new_seq(1, .length_out = 0.5, .obs_only = TRUE),
+    "`.length_out` must be a count"
   )
   # length_out is 0
-  expect_identical(new_seq(double(), length_out = 0), double())
-  expect_identical(new_seq(numeric(), length_out = 0), double())
-  expect_identical(new_seq(NA_real_, length_out = 0), double())
-  expect_identical(new_seq(1, length_out = 0), double())
-  expect_identical(new_seq(double(), length_out = 0, obs_only = TRUE), double())
+  expect_identical(new_seq(double(), .length_out = 0), double())
+  expect_identical(new_seq(numeric(), .length_out = 0), double())
+  expect_identical(new_seq(NA_real_, .length_out = 0), double())
+  expect_identical(new_seq(1, .length_out = 0), double())
   expect_identical(
-    new_seq(numeric(), length_out = 0, obs_only = TRUE),
+    new_seq(double(), .length_out = 0, .obs_only = TRUE),
     double()
   )
-  expect_identical(new_seq(NA_real_, length_out = 0, obs_only = TRUE), double())
-  expect_identical(new_seq(1, length_out = 0, obs_only = TRUE), double())
-  # length_out = 1
-  expect_identical(new_seq(c(0, 1), length_out = 1), 0.5)
-  expect_identical(new_seq(c(1, 0), length_out = 1), 0.5)
-  expect_identical(new_seq(c(1, 1), length_out = 1), 1)
-  expect_identical(new_seq(c(0, 0), length_out = 1), 0)
-  expect_equal(new_seq(c(0, 0, 1), length_out = 1), 1 / 3)
-  expect_identical(new_seq(c(1, 1, 0), length_out = 1), 2 / 3)
-  expect_identical(new_seq(c(10, 1), length_out = 1), 5.5)
-  expect_identical(new_seq(c(100, 1), length_out = 1), 50.5)
-  expect_identical(new_seq(c(0, 1), length_out = 1, obs_only = TRUE), 0)
-  expect_identical(new_seq(c(1, 0), length_out = 1, obs_only = TRUE), 0)
-  expect_identical(new_seq(c(1, 1), length_out = 1, obs_only = TRUE), 1)
-  expect_identical(new_seq(c(0, 0), length_out = 1, obs_only = TRUE), 0)
-  expect_equal(new_seq(c(0, 0, 1), length_out = 1, obs_only = TRUE), 0)
-  expect_identical(new_seq(c(1, 1, 0), length_out = 1, obs_only = TRUE), 0)
-  expect_identical(new_seq(c(10, 1), length_out = 1, obs_only = TRUE), 1)
-  expect_identical(new_seq(c(100, 1), length_out = 1, obs_only = TRUE), 1)
-  # length_out = 2
-  expect_identical(new_seq(c(0, 1), length_out = 2), c(0, 1))
-  expect_identical(new_seq(c(1, 0), length_out = 2), c(0, 1))
-  expect_identical(new_seq(c(1, 1), length_out = 2), 1)
-  expect_identical(new_seq(c(0, 0), length_out = 2), 0)
-  expect_identical(new_seq(c(0, 0, 1), length_out = 2), c(0, 1))
-  expect_identical(new_seq(c(1, 1, 0), length_out = 2), c(0, 1))
-  expect_identical(new_seq(c(10, 1), length_out = 2), c(1, 10))
-  expect_identical(new_seq(c(100, 1), length_out = 2), c(1, 100))
-  expect_identical(new_seq(c(0, 1), length_out = 2, obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 0), length_out = 2, obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 1), length_out = 2, obs_only = TRUE), 1)
-  expect_identical(new_seq(c(0, 0), length_out = 2, obs_only = TRUE), 0)
   expect_identical(
-    new_seq(c(0, 0, 1), length_out = 2, obs_only = TRUE),
+    new_seq(numeric(), .length_out = 0, .obs_only = TRUE),
+    double()
+  )
+  expect_identical(
+    new_seq(NA_real_, .length_out = 0, .obs_only = TRUE),
+    double()
+  )
+  expect_identical(new_seq(1, .length_out = 0, .obs_only = TRUE), double())
+  # .length_out = 1
+  expect_identical(new_seq(c(0, 1), .length_out = 1), 0.5)
+  expect_identical(new_seq(c(1, 0), .length_out = 1), 0.5)
+  expect_identical(new_seq(c(1, 1), .length_out = 1), 1)
+  expect_identical(new_seq(c(0, 0), .length_out = 1), 0)
+  expect_equal(new_seq(c(0, 0, 1), .length_out = 1), 1 / 3)
+  expect_identical(new_seq(c(1, 1, 0), .length_out = 1), 2 / 3)
+  expect_identical(new_seq(c(10, 1), .length_out = 1), 5.5)
+  expect_identical(new_seq(c(100, 1), .length_out = 1), 50.5)
+  expect_identical(new_seq(c(0, 1), .length_out = 1, .obs_only = TRUE), 0)
+  expect_identical(new_seq(c(1, 0), .length_out = 1, .obs_only = TRUE), 0)
+  expect_identical(new_seq(c(1, 1), .length_out = 1, .obs_only = TRUE), 1)
+  expect_identical(new_seq(c(0, 0), .length_out = 1, .obs_only = TRUE), 0)
+  expect_equal(new_seq(c(0, 0, 1), .length_out = 1, .obs_only = TRUE), 0)
+  expect_identical(new_seq(c(1, 1, 0), .length_out = 1, .obs_only = TRUE), 0)
+  expect_identical(new_seq(c(10, 1), .length_out = 1, .obs_only = TRUE), 1)
+  expect_identical(new_seq(c(100, 1), .length_out = 1, .obs_only = TRUE), 1)
+  # .length_out = 2
+  expect_identical(new_seq(c(0, 1), .length_out = 2), c(0, 1))
+  expect_identical(new_seq(c(1, 0), .length_out = 2), c(0, 1))
+  expect_identical(new_seq(c(1, 1), .length_out = 2), 1)
+  expect_identical(new_seq(c(0, 0), .length_out = 2), 0)
+  expect_identical(new_seq(c(0, 0, 1), .length_out = 2), c(0, 1))
+  expect_identical(new_seq(c(1, 1, 0), .length_out = 2), c(0, 1))
+  expect_identical(new_seq(c(10, 1), .length_out = 2), c(1, 10))
+  expect_identical(new_seq(c(100, 1), .length_out = 2), c(1, 100))
+  expect_identical(new_seq(c(0, 1), .length_out = 2, .obs_only = TRUE), c(0, 1))
+  expect_identical(new_seq(c(1, 0), .length_out = 2, .obs_only = TRUE), c(0, 1))
+  expect_identical(new_seq(c(1, 1), .length_out = 2, .obs_only = TRUE), 1)
+  expect_identical(new_seq(c(0, 0), .length_out = 2, .obs_only = TRUE), 0)
+  expect_identical(
+    new_seq(c(0, 0, 1), .length_out = 2, .obs_only = TRUE),
     c(0, 1)
   )
   expect_identical(
-    new_seq(c(1, 1, 0), length_out = 2, obs_only = TRUE),
+    new_seq(c(1, 1, 0), .length_out = 2, .obs_only = TRUE),
     c(0, 1)
   )
-  expect_identical(new_seq(c(10, 1), length_out = 2, obs_only = TRUE), c(1, 10))
   expect_identical(
-    new_seq(c(100, 1), length_out = 2, obs_only = TRUE),
+    new_seq(c(10, 1), .length_out = 2, .obs_only = TRUE),
+    c(1, 10)
+  )
+  expect_identical(
+    new_seq(c(100, 1), .length_out = 2, .obs_only = TRUE),
     c(1, 100)
   )
-  # length_out = 3
-  expect_identical(new_seq(c(0, 1), length_out = 3), c(0, 0.5, 1))
-  expect_identical(new_seq(c(1, 0), length_out = 3), c(0, 0.5, 1))
-  expect_identical(new_seq(c(1, 1), length_out = 3), 1)
-  expect_identical(new_seq(c(0, 0), length_out = 3), 0)
-  expect_identical(new_seq(c(0, 0, 1), length_out = 3), c(0, 0.5, 1))
-  expect_identical(new_seq(c(1, 1, 0), length_out = 3), c(0, 0.5, 1))
-  expect_identical(new_seq(c(10, 1), length_out = 3), c(1, 5.5, 10))
-  expect_identical(new_seq(c(100, 1), length_out = 3), c(1, 50.5, 100))
-  expect_identical(new_seq(c(0, 1), length_out = 3, obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 0), length_out = 3, obs_only = TRUE), c(0, 1))
-  expect_identical(new_seq(c(1, 1), length_out = 3, obs_only = TRUE), 1)
-  expect_identical(new_seq(c(0, 0), length_out = 3, obs_only = TRUE), 0)
+  # .length_out = 3
+  expect_identical(new_seq(c(0, 1), .length_out = 3), c(0, 0.5, 1))
+  expect_identical(new_seq(c(1, 0), .length_out = 3), c(0, 0.5, 1))
+  expect_identical(new_seq(c(1, 1), .length_out = 3), 1)
+  expect_identical(new_seq(c(0, 0), .length_out = 3), 0)
+  expect_identical(new_seq(c(0, 0, 1), .length_out = 3), c(0, 0.5, 1))
+  expect_identical(new_seq(c(1, 1, 0), .length_out = 3), c(0, 0.5, 1))
+  expect_identical(new_seq(c(10, 1), .length_out = 3), c(1, 5.5, 10))
+  expect_identical(new_seq(c(100, 1), .length_out = 3), c(1, 50.5, 100))
+  expect_identical(new_seq(c(0, 1), .length_out = 3, .obs_only = TRUE), c(0, 1))
+  expect_identical(new_seq(c(1, 0), .length_out = 3, .obs_only = TRUE), c(0, 1))
+  expect_identical(new_seq(c(1, 1), .length_out = 3, .obs_only = TRUE), 1)
+  expect_identical(new_seq(c(0, 0), .length_out = 3, .obs_only = TRUE), 0)
   expect_identical(
-    new_seq(c(0, 0, 1), length_out = 3, obs_only = TRUE),
+    new_seq(c(0, 0, 1), .length_out = 3, .obs_only = TRUE),
     c(0, 1)
   )
   expect_identical(
-    new_seq(c(1, 1, 0), length_out = 3, obs_only = TRUE),
+    new_seq(c(1, 1, 0), .length_out = 3, .obs_only = TRUE),
     c(0, 1)
   )
-  expect_identical(new_seq(c(10, 1), length_out = 3, obs_only = TRUE), c(1, 10))
   expect_identical(
-    new_seq(c(100, 1), length_out = 3, obs_only = TRUE),
+    new_seq(c(10, 1), .length_out = 3, .obs_only = TRUE),
+    c(1, 10)
+  )
+  expect_identical(
+    new_seq(c(100, 1), .length_out = 3, .obs_only = TRUE),
     c(1, 100)
   )
-  # length_out = Inf
+  # .length_out = Inf
   expect_error(
-    new_seq(c(0, 1), length_out = Inf),
-    "^`length_out` must be less than Inf, not Inf[.]$"
+    new_seq(c(0, 1), .length_out = Inf),
+    "^`.length_out` must be less than Inf, not Inf[.]$"
   ) # improve error message
   # matrices and arrays
   expect_identical(new_seq(matrix(1)), 1)
@@ -759,57 +789,57 @@ test_that("new_seq character", {
   expect_identical(new_seq(c("10", "1", NA)), c("1", "10"))
   expect_identical(new_seq(c("100", "1", NA)), c("1", "100"))
   # length_out not count
-  expect_error(new_seq("1", length_out = -1), "`length_out` must be a count")
-  expect_error(new_seq("1", length_out = 0.5), "`length_out` must be a count")
+  expect_error(new_seq("1", .length_out = -1), "`.length_out` must be a count")
+  expect_error(new_seq("1", .length_out = 0.5), "`.length_out` must be a count")
   # length_out is 0
-  expect_identical(new_seq(character(), length_out = 0), character())
-  expect_identical(new_seq(NA_character_, length_out = 0), character())
-  expect_identical(new_seq("1", length_out = 0), character())
-  # length_out = 1
-  expect_identical(new_seq(c("0", "1"), length_out = 1), "0")
-  expect_identical(new_seq(c("1", "0"), length_out = 1), "0")
-  expect_identical(new_seq(c("1", "1"), length_out = 1), "1")
-  expect_identical(new_seq(c("0", "0"), length_out = 1), "0")
-  expect_identical(new_seq(c("0", "0", "1"), length_out = 1), "0")
-  expect_identical(new_seq(c("1", "1", "0"), length_out = 1), "1")
-  expect_identical(new_seq(c("1", "0", "1"), length_out = 1), "1")
-  expect_identical(new_seq(c("10", "1"), length_out = 1), "1")
-  expect_identical(new_seq(c("100", "1"), length_out = 1), "1")
-  # length_out = 2
-  expect_identical(new_seq(c("0", "1"), length_out = 2), c("0", "1"))
-  expect_identical(new_seq(c("1", "0"), length_out = 2), c("0", "1"))
-  expect_identical(new_seq(c("1", "1"), length_out = 2), "1")
-  expect_identical(new_seq(c("0", "0"), length_out = 2), "0")
-  expect_identical(new_seq(c("0", "0", "1"), length_out = 2), c("0", "1"))
-  expect_identical(new_seq(c("1", "1", "0"), length_out = 2), c("1", "0"))
-  expect_identical(new_seq(c("10", "1"), length_out = 2), c("1", "10"))
-  expect_identical(new_seq(c("100", "1"), length_out = 2), c("1", "100"))
-  expect_identical(new_seq(c("10", "1", "2"), length_out = 2), c("1", "10"))
-  expect_identical(new_seq(c("100", "1", "2"), length_out = 2), c("1", "100"))
-  # length_out = 3
-  expect_identical(new_seq(c("0", "1"), length_out = 3), c("0", "1"))
-  expect_identical(new_seq(c("1", "0"), length_out = 3), c("0", "1"))
-  expect_identical(new_seq(c("1", "1"), length_out = 3), "1")
-  expect_identical(new_seq(c("0", "0"), length_out = 3), "0")
-  expect_identical(new_seq(c("0", "0", "1"), length_out = 3), c("0", "1"))
-  expect_identical(new_seq(c("1", "1", "0"), length_out = 3), c("1", "0"))
-  expect_identical(new_seq(c("10", "1"), length_out = 3), c("1", "10"))
-  expect_identical(new_seq(c("100", "1"), length_out = 3), c("1", "100"))
+  expect_identical(new_seq(character(), .length_out = 0), character())
+  expect_identical(new_seq(NA_character_, .length_out = 0), character())
+  expect_identical(new_seq("1", .length_out = 0), character())
+  # .length_out = 1
+  expect_identical(new_seq(c("0", "1"), .length_out = 1), "0")
+  expect_identical(new_seq(c("1", "0"), .length_out = 1), "0")
+  expect_identical(new_seq(c("1", "1"), .length_out = 1), "1")
+  expect_identical(new_seq(c("0", "0"), .length_out = 1), "0")
+  expect_identical(new_seq(c("0", "0", "1"), .length_out = 1), "0")
+  expect_identical(new_seq(c("1", "1", "0"), .length_out = 1), "1")
+  expect_identical(new_seq(c("1", "0", "1"), .length_out = 1), "1")
+  expect_identical(new_seq(c("10", "1"), .length_out = 1), "1")
+  expect_identical(new_seq(c("100", "1"), .length_out = 1), "1")
+  # .length_out = 2
+  expect_identical(new_seq(c("0", "1"), .length_out = 2), c("0", "1"))
+  expect_identical(new_seq(c("1", "0"), .length_out = 2), c("0", "1"))
+  expect_identical(new_seq(c("1", "1"), .length_out = 2), "1")
+  expect_identical(new_seq(c("0", "0"), .length_out = 2), "0")
+  expect_identical(new_seq(c("0", "0", "1"), .length_out = 2), c("0", "1"))
+  expect_identical(new_seq(c("1", "1", "0"), .length_out = 2), c("1", "0"))
+  expect_identical(new_seq(c("10", "1"), .length_out = 2), c("1", "10"))
+  expect_identical(new_seq(c("100", "1"), .length_out = 2), c("1", "100"))
+  expect_identical(new_seq(c("10", "1", "2"), .length_out = 2), c("1", "10"))
+  expect_identical(new_seq(c("100", "1", "2"), .length_out = 2), c("1", "100"))
+  # .length_out = 3
+  expect_identical(new_seq(c("0", "1"), .length_out = 3), c("0", "1"))
+  expect_identical(new_seq(c("1", "0"), .length_out = 3), c("0", "1"))
+  expect_identical(new_seq(c("1", "1"), .length_out = 3), "1")
+  expect_identical(new_seq(c("0", "0"), .length_out = 3), "0")
+  expect_identical(new_seq(c("0", "0", "1"), .length_out = 3), c("0", "1"))
+  expect_identical(new_seq(c("1", "1", "0"), .length_out = 3), c("1", "0"))
+  expect_identical(new_seq(c("10", "1"), .length_out = 3), c("1", "10"))
+  expect_identical(new_seq(c("100", "1"), .length_out = 3), c("1", "100"))
   expect_identical(
-    new_seq(c("100", "1", "2"), length_out = 3),
+    new_seq(c("100", "1", "2"), .length_out = 3),
     c("1", "100", "2")
   )
   expect_identical(
-    new_seq(c("100", "1", "2", "3"), length_out = 3),
+    new_seq(c("100", "1", "2", "3"), .length_out = 3),
     c("1", "100", "2")
   )
   expect_identical(
-    new_seq(c("100", "1", "99", "3"), length_out = 3),
+    new_seq(c("100", "1", "99", "3"), .length_out = 3),
     c("1", "100", "3")
   )
-  # length_out = Inf
+  # .length_out = Inf
   expect_identical(
-    new_seq(as.character(1:100), length_out = Inf),
+    new_seq(as.character(1:100), .length_out = Inf),
     sort(as.character(1:100))
   )
   # matrices and arrays
@@ -898,166 +928,166 @@ test_that("new_seq factor", {
   )
   # length_out not count
   expect_error(
-    new_seq(factor("1"), length_out = -1),
-    "`length_out` must be a count"
+    new_seq(factor("1"), .length_out = -1),
+    "`.length_out` must be a count"
   )
   expect_error(
-    new_seq(factor("1"), length_out = 0.5),
-    "`length_out` must be a count"
+    new_seq(factor("1"), .length_out = 0.5),
+    "`.length_out` must be a count"
   )
   # length_out is 0
-  expect_identical(new_seq(factor(), length_out = 0), factor())
+  expect_identical(new_seq(factor(), .length_out = 0), factor())
   expect_identical(
-    new_seq(factor(levels = "1"), length_out = 0),
+    new_seq(factor(levels = "1"), .length_out = 0),
     factor(levels = "1")
   )
-  expect_identical(new_seq(factor(NA_character_), length_out = 0), factor())
+  expect_identical(new_seq(factor(NA_character_), .length_out = 0), factor())
   expect_identical(
-    new_seq(factor(NA_character_, levels = "1"), length_out = 0),
+    new_seq(factor(NA_character_, levels = "1"), .length_out = 0),
     factor(levels = "1")
   )
-  expect_identical(new_seq(factor("1"), length_out = 0), factor(levels = "1"))
-  # length_out = 1
+  expect_identical(new_seq(factor("1"), .length_out = 0), factor(levels = "1"))
+  # .length_out = 1
   expect_identical(
-    new_seq(factor(c("0", "1"), levels = c("0", "1")), length_out = 1),
+    new_seq(factor(c("0", "1"), levels = c("0", "1")), .length_out = 1),
     factor("0", levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor(c("1", "0"), levels = c("0", "1")), length_out = 1),
+    new_seq(factor(c("1", "0"), levels = c("0", "1")), .length_out = 1),
     factor("0", levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor(c("0", "1"), levels = c("1", "0")), length_out = 1),
+    new_seq(factor(c("0", "1"), levels = c("1", "0")), .length_out = 1),
     factor("1", levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(factor(c("1", "0"), levels = c("1", "0")), length_out = 1),
+    new_seq(factor(c("1", "0"), levels = c("1", "0")), .length_out = 1),
     factor("1", levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(factor(c("0", "0", "1"), levels = c("0", "1")), length_out = 1),
+    new_seq(factor(c("0", "0", "1"), levels = c("0", "1")), .length_out = 1),
     factor("0", levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor(c("1", "1", "0"), levels = c("0", "1")), length_out = 1),
+    new_seq(factor(c("1", "1", "0"), levels = c("0", "1")), .length_out = 1),
     factor("0", levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor("0", levels = c("0", "1", "2")), length_out = 1),
+    new_seq(factor("0", levels = c("0", "1", "2")), .length_out = 1),
     factor("0", levels = c("0", "1", "2"))
   )
   expect_identical(
     new_seq(
       factor(c("2", "1", "0"), levels = c("0", "1", "2")),
-      length_out = 1
+      .length_out = 1
     ),
     factor("0", levels = c("0", "1", "2"))
   )
-  # length_out = 2
+  # .length_out = 2
   expect_identical(
-    new_seq(factor(c("0", "1"), levels = c("0", "1")), length_out = 2),
+    new_seq(factor(c("0", "1"), levels = c("0", "1")), .length_out = 2),
     factor(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor(c("1", "0"), levels = c("0", "1")), length_out = 2),
+    new_seq(factor(c("1", "0"), levels = c("0", "1")), .length_out = 2),
     factor(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor(c("0", "1"), levels = c("1", "0")), length_out = 2),
+    new_seq(factor(c("0", "1"), levels = c("1", "0")), .length_out = 2),
     factor(c("1", "0"), levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(factor(c("1", "0"), levels = c("1", "0")), length_out = 2),
+    new_seq(factor(c("1", "0"), levels = c("1", "0")), .length_out = 2),
     factor(c("1", "0"), levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(factor(c("0", "0", "1"), levels = c("0", "1")), length_out = 2),
+    new_seq(factor(c("0", "0", "1"), levels = c("0", "1")), .length_out = 2),
     factor(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor(c("1", "1", "0"), levels = c("0", "1")), length_out = 2),
+    new_seq(factor(c("1", "1", "0"), levels = c("0", "1")), .length_out = 2),
     factor(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor("0", levels = c("0", "1", "2")), length_out = 2),
+    new_seq(factor("0", levels = c("0", "1", "2")), .length_out = 2),
     factor(c("0", "1"), levels = c("0", "1", "2"))
   )
   expect_identical(
     new_seq(
       factor(c("2", "1", "0"), levels = c("0", "1", "2")),
-      length_out = 2
+      .length_out = 2
     ),
     factor(c("0", "1"), levels = c("0", "1", "2"))
   )
   expect_identical(
     new_seq(
       factor(c("10", "1", "2"), levels = c("1", "10", "2")),
-      length_out = 2
+      .length_out = 2
     ),
     factor(c("1", "10"), levels = c("1", "10", "2"))
   )
   expect_identical(
     new_seq(
       factor(c("100", "1", "2"), levels = c("1", "10", "2")),
-      length_out = 2
+      .length_out = 2
     ),
     factor(c("1", "10"), levels = c("1", "10", "2"))
   )
-  # length_out = 3
+  # .length_out = 3
   expect_identical(
-    new_seq(factor(c("0", "1"), levels = c("0", "1")), length_out = 3),
+    new_seq(factor(c("0", "1"), levels = c("0", "1")), .length_out = 3),
     factor(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor(c("1", "0"), levels = c("0", "1")), length_out = 3),
+    new_seq(factor(c("1", "0"), levels = c("0", "1")), .length_out = 3),
     factor(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor(c("0", "1"), levels = c("1", "0")), length_out = 3),
+    new_seq(factor(c("0", "1"), levels = c("1", "0")), .length_out = 3),
     factor(c("1", "0"), levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(factor(c("1", "0"), levels = c("1", "0")), length_out = 3),
+    new_seq(factor(c("1", "0"), levels = c("1", "0")), .length_out = 3),
     factor(c("1", "0"), levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(factor(c("0", "0", "1"), levels = c("0", "1")), length_out = 3),
+    new_seq(factor(c("0", "0", "1"), levels = c("0", "1")), .length_out = 3),
     factor(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor(c("1", "1", "0"), levels = c("0", "1")), length_out = 3),
+    new_seq(factor(c("1", "1", "0"), levels = c("0", "1")), .length_out = 3),
     factor(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(factor("0", levels = c("0", "1", "2")), length_out = 3),
+    new_seq(factor("0", levels = c("0", "1", "2")), .length_out = 3),
     factor(c("0", "1", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
     new_seq(
       factor(c("2", "1", "0"), levels = c("0", "1", "2")),
-      length_out = 3
+      .length_out = 3
     ),
     factor(c("0", "1", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
     new_seq(
       factor(c("10", "1", "2"), levels = c("1", "10", "2")),
-      length_out = 3
+      .length_out = 3
     ),
     factor(c("1", "10", "2"), levels = c("1", "10", "2"))
   )
   expect_identical(
     new_seq(
       factor(c("100", "1", "2"), levels = c("1", "2", "100")),
-      length_out = 3
+      .length_out = 3
     ),
     factor(c("1", "2", "100"), levels = c("1", "2", "100"))
   )
-  # length_out = Inf
+  # .length_out = Inf
   expect_identical(
     new_seq(
       factor(c("100", "1", "2"), levels = c("1", "2", "100")),
-      length_out = Inf
+      .length_out = Inf
     ),
     factor(c("1", "2", "100"), levels = c("1", "2", "100"))
   )
@@ -1147,166 +1177,169 @@ test_that("new_seq ordered", {
   )
   # length_out not count
   expect_error(
-    new_seq(ordered("1"), length_out = -1),
-    "`length_out` must be a count"
+    new_seq(ordered("1"), .length_out = -1),
+    "`.length_out` must be a count"
   )
   expect_error(
-    new_seq(ordered("1"), length_out = 0.5),
-    "`length_out` must be a count"
+    new_seq(ordered("1"), .length_out = 0.5),
+    "`.length_out` must be a count"
   )
   # length_out is 0
-  expect_identical(new_seq(ordered(), length_out = 0), ordered())
+  expect_identical(new_seq(ordered(), .length_out = 0), ordered())
   expect_identical(
-    new_seq(ordered(levels = "1"), length_out = 0),
+    new_seq(ordered(levels = "1"), .length_out = 0),
     ordered(levels = "1")
   )
-  expect_identical(new_seq(ordered(NA_character_), length_out = 0), ordered())
+  expect_identical(new_seq(ordered(NA_character_), .length_out = 0), ordered())
   expect_identical(
-    new_seq(ordered(NA_character_, levels = "1"), length_out = 0),
+    new_seq(ordered(NA_character_, levels = "1"), .length_out = 0),
     ordered(levels = "1")
   )
-  expect_identical(new_seq(ordered("1"), length_out = 0), ordered(levels = "1"))
-  # length_out = 1
   expect_identical(
-    new_seq(ordered(c("0", "1"), levels = c("0", "1")), length_out = 1),
+    new_seq(ordered("1"), .length_out = 0),
+    ordered(levels = "1")
+  )
+  # .length_out = 1
+  expect_identical(
+    new_seq(ordered(c("0", "1"), levels = c("0", "1")), .length_out = 1),
     ordered("0", levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered(c("1", "0"), levels = c("0", "1")), length_out = 1),
+    new_seq(ordered(c("1", "0"), levels = c("0", "1")), .length_out = 1),
     ordered("0", levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered(c("0", "1"), levels = c("1", "0")), length_out = 1),
+    new_seq(ordered(c("0", "1"), levels = c("1", "0")), .length_out = 1),
     ordered("1", levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(ordered(c("1", "0"), levels = c("1", "0")), length_out = 1),
+    new_seq(ordered(c("1", "0"), levels = c("1", "0")), .length_out = 1),
     ordered("1", levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(ordered(c("0", "0", "1"), levels = c("0", "1")), length_out = 1),
+    new_seq(ordered(c("0", "0", "1"), levels = c("0", "1")), .length_out = 1),
     ordered("0", levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered(c("1", "1", "0"), levels = c("0", "1")), length_out = 1),
+    new_seq(ordered(c("1", "1", "0"), levels = c("0", "1")), .length_out = 1),
     ordered("0", levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered("0", levels = c("0", "1", "2")), length_out = 1),
+    new_seq(ordered("0", levels = c("0", "1", "2")), .length_out = 1),
     ordered("1", levels = c("0", "1", "2"))
   )
   expect_identical(
     new_seq(
       ordered(c("2", "1", "0"), levels = c("0", "1", "2")),
-      length_out = 1
+      .length_out = 1
     ),
     ordered("1", levels = c("0", "1", "2"))
   )
-  # length_out = 2
+  # .length_out = 2
   expect_identical(
-    new_seq(ordered(c("0", "1"), levels = c("0", "1")), length_out = 2),
+    new_seq(ordered(c("0", "1"), levels = c("0", "1")), .length_out = 2),
     ordered(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered(c("1", "0"), levels = c("0", "1")), length_out = 2),
+    new_seq(ordered(c("1", "0"), levels = c("0", "1")), .length_out = 2),
     ordered(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered(c("0", "1"), levels = c("1", "0")), length_out = 2),
+    new_seq(ordered(c("0", "1"), levels = c("1", "0")), .length_out = 2),
     ordered(c("1", "0"), levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(ordered(c("1", "0"), levels = c("1", "0")), length_out = 2),
+    new_seq(ordered(c("1", "0"), levels = c("1", "0")), .length_out = 2),
     ordered(c("1", "0"), levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(ordered(c("0", "0", "1"), levels = c("0", "1")), length_out = 2),
+    new_seq(ordered(c("0", "0", "1"), levels = c("0", "1")), .length_out = 2),
     ordered(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered(c("1", "1", "0"), levels = c("0", "1")), length_out = 2),
+    new_seq(ordered(c("1", "1", "0"), levels = c("0", "1")), .length_out = 2),
     ordered(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered("0", levels = c("0", "1", "2")), length_out = 2),
+    new_seq(ordered("0", levels = c("0", "1", "2")), .length_out = 2),
     ordered(c("0", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
     new_seq(
       ordered(c("2", "1", "0"), levels = c("0", "1", "2")),
-      length_out = 2
+      .length_out = 2
     ),
     ordered(c("0", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
     new_seq(
       ordered(c("10", "1", "2"), levels = c("1", "10", "2")),
-      length_out = 2
+      .length_out = 2
     ),
     ordered(c("1", "2"), levels = c("1", "10", "2"))
   )
   expect_identical(
     new_seq(
       ordered(c("100", "1", "2"), levels = c("1", "10", "2")),
-      length_out = 2
+      .length_out = 2
     ),
     ordered(c("1", "2"), levels = c("1", "10", "2"))
   )
-  # length_out = 3
+  # .length_out = 3
   expect_identical(
-    new_seq(ordered(c("0", "1"), levels = c("0", "1")), length_out = 3),
+    new_seq(ordered(c("0", "1"), levels = c("0", "1")), .length_out = 3),
     ordered(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered(c("1", "0"), levels = c("0", "1")), length_out = 3),
+    new_seq(ordered(c("1", "0"), levels = c("0", "1")), .length_out = 3),
     ordered(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered(c("0", "1"), levels = c("1", "0")), length_out = 3),
+    new_seq(ordered(c("0", "1"), levels = c("1", "0")), .length_out = 3),
     ordered(c("1", "0"), levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(ordered(c("1", "0"), levels = c("1", "0")), length_out = 3),
+    new_seq(ordered(c("1", "0"), levels = c("1", "0")), .length_out = 3),
     ordered(c("1", "0"), levels = c("1", "0"))
   )
   expect_identical(
-    new_seq(ordered(c("0", "0", "1"), levels = c("0", "1")), length_out = 3),
+    new_seq(ordered(c("0", "0", "1"), levels = c("0", "1")), .length_out = 3),
     ordered(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered(c("1", "1", "0"), levels = c("0", "1")), length_out = 3),
+    new_seq(ordered(c("1", "1", "0"), levels = c("0", "1")), .length_out = 3),
     ordered(c("0", "1"), levels = c("0", "1"))
   )
   expect_identical(
-    new_seq(ordered("0", levels = c("0", "1", "2")), length_out = 3),
+    new_seq(ordered("0", levels = c("0", "1", "2")), .length_out = 3),
     ordered(c("0", "1", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
     new_seq(
       ordered(c("2", "1", "0"), levels = c("0", "1", "2")),
-      length_out = 3
+      .length_out = 3
     ),
     ordered(c("0", "1", "2"), levels = c("0", "1", "2"))
   )
   expect_identical(
     new_seq(
       ordered(c("10", "1", "2"), levels = c("1", "10", "2")),
-      length_out = 3
+      .length_out = 3
     ),
     ordered(c("1", "10", "2"), levels = c("1", "10", "2"))
   )
   expect_identical(
     new_seq(
       ordered(c("100", "1", "2"), levels = c("1", "2", "100")),
-      length_out = 3
+      .length_out = 3
     ),
     ordered(c("1", "2", "100"), levels = c("1", "2", "100"))
   )
-  # length_out = Inf
+  # .length_out = Inf
   expect_identical(
     new_seq(
       ordered(c("100", "1", "2"), levels = c("1", "2", "100")),
-      length_out = Inf
+      .length_out = Inf
     ),
     ordered(c("1", "2", "100"), levels = c("1", "2", "100"))
   )
@@ -1318,15 +1351,15 @@ test_that("new_seq Date", {
   expect_identical(new_seq(as.Date(integer(0))), as.Date(NA_integer_))
   expect_identical(new_seq(as.Date(double(0))), as.Date(NA_integer_))
   expect_identical(
-    new_seq(as.Date(character(0)), obs_only = TRUE),
+    new_seq(as.Date(character(0)), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   expect_identical(
-    new_seq(as.Date(integer(0)), obs_only = TRUE),
+    new_seq(as.Date(integer(0)), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   expect_identical(
-    new_seq(as.Date(double(0)), obs_only = TRUE),
+    new_seq(as.Date(double(0)), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   # missing value
@@ -1334,24 +1367,24 @@ test_that("new_seq Date", {
   expect_identical(new_seq(as.Date(NA_integer_)), as.Date(NA_integer_))
   expect_identical(new_seq(as.Date(NA_real_)), as.Date(NA_integer_))
   expect_identical(
-    new_seq(as.Date(NA_character_), obs_only = TRUE),
+    new_seq(as.Date(NA_character_), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   expect_identical(
-    new_seq(as.Date(NA_integer_), obs_only = TRUE),
+    new_seq(as.Date(NA_integer_), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   expect_identical(
-    new_seq(as.Date(NA_real_), obs_only = TRUE),
+    new_seq(as.Date(NA_real_), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   # single value
   expect_identical(new_seq(as.Date(1L)), as.Date(1L))
   expect_identical(new_seq(as.Date(1)), as.Date(1L))
   expect_identical(new_seq(as.Date(0L)), as.Date(0L))
-  expect_identical(new_seq(as.Date(1L), obs_only = TRUE), as.Date(1L))
-  expect_identical(new_seq(as.Date(1), obs_only = TRUE), as.Date(1L))
-  expect_identical(new_seq(as.Date(0L), obs_only = TRUE), as.Date(0L))
+  expect_identical(new_seq(as.Date(1L), .obs_only = TRUE), as.Date(1L))
+  expect_identical(new_seq(as.Date(1), .obs_only = TRUE), as.Date(1L))
+  expect_identical(new_seq(as.Date(0L), .obs_only = TRUE), as.Date(0L))
   # multiple value
   expect_identical(new_seq(as.Date(c(0L, 1L))), as.Date(c(0L, 1L)))
   expect_identical(new_seq(as.Date(c(1L, 0L))), as.Date(c(0L, 1L)))
@@ -1396,29 +1429,29 @@ test_that("new_seq Date", {
     ))
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 1L)), obs_only = TRUE),
+    new_seq(as.Date(c(0L, 1L)), .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 0L)), obs_only = TRUE),
+    new_seq(as.Date(c(1L, 0L)), .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
-  expect_identical(new_seq(as.Date(c(1L, 1L)), obs_only = TRUE), as.Date(1L))
-  expect_identical(new_seq(as.Date(c(0L, 0L)), obs_only = TRUE), as.Date(0L))
+  expect_identical(new_seq(as.Date(c(1L, 1L)), .obs_only = TRUE), as.Date(1L))
+  expect_identical(new_seq(as.Date(c(0L, 0L)), .obs_only = TRUE), as.Date(0L))
   expect_identical(
-    new_seq(as.Date(c(0L, 0L, 1L)), obs_only = TRUE),
-    as.Date(c(0L, 1L))
-  )
-  expect_identical(
-    new_seq(as.Date(c(1L, 1L, 0L)), obs_only = TRUE),
+    new_seq(as.Date(c(0L, 0L, 1L)), .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(10L, 1L)), obs_only = TRUE),
+    new_seq(as.Date(c(1L, 1L, 0L)), .obs_only = TRUE),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), .obs_only = TRUE),
     as.Date(c(1L, 10L))
   )
   expect_identical(
-    new_seq(as.Date(c(100L, 1L)), obs_only = TRUE),
+    new_seq(as.Date(c(100L, 1L)), .obs_only = TRUE),
     as.Date(c(1L, 100L))
   )
   # multiple value with missing
@@ -1465,245 +1498,251 @@ test_that("new_seq Date", {
     ))
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 1L, NA)), obs_only = TRUE),
+    new_seq(as.Date(c(0L, 1L, NA)), .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 0L, NA)), obs_only = TRUE),
+    new_seq(as.Date(c(1L, 0L, NA)), .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 1L, NA)), obs_only = TRUE),
+    new_seq(as.Date(c(1L, 1L, NA)), .obs_only = TRUE),
     as.Date(1L)
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 0L, NA)), obs_only = TRUE),
+    new_seq(as.Date(c(0L, 0L, NA)), .obs_only = TRUE),
     as.Date(0L)
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 0L, 1L, NA)), obs_only = TRUE),
+    new_seq(as.Date(c(0L, 0L, 1L, NA)), .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 1L, 0L, NA)), obs_only = TRUE),
+    new_seq(as.Date(c(1L, 1L, 0L, NA)), .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(10L, 1L, NA)), obs_only = TRUE),
+    new_seq(as.Date(c(10L, 1L, NA)), .obs_only = TRUE),
     as.Date(c(1L, 10L))
   )
   expect_identical(
-    new_seq(as.Date(c(100L, 1L, NA)), obs_only = TRUE),
+    new_seq(as.Date(c(100L, 1L, NA)), .obs_only = TRUE),
     as.Date(c(1L, 100L))
   )
   # length_out not count
   expect_error(
-    new_seq(as.Date(1L), length_out = -1),
-    "`length_out` must be a count"
+    new_seq(as.Date(1L), .length_out = -1),
+    "`.length_out` must be a count"
   )
   expect_error(
-    new_seq(as.Date(1L), length_out = 0.5),
-    "`length_out` must be a count"
+    new_seq(as.Date(1L), .length_out = 0.5),
+    "`.length_out` must be a count"
   )
   # length_out is 0
   expect_identical(
-    new_seq(as.Date(integer()), length_out = 0),
+    new_seq(as.Date(integer()), .length_out = 0),
     as.Date(integer())
   )
   expect_identical(
-    new_seq(as.Date(NA_integer_), length_out = 0),
+    new_seq(as.Date(NA_integer_), .length_out = 0),
     as.Date(integer())
   )
   expect_identical(
-    new_seq(as.Date(1L), length_out = 0),
+    new_seq(as.Date(1L), .length_out = 0),
     as.Date(integer())
   )
   expect_identical(
-    new_seq(as.Date(integer()), length_out = 0, obs_only = TRUE),
+    new_seq(as.Date(integer()), .length_out = 0, .obs_only = TRUE),
     as.Date(integer())
   )
   expect_identical(
-    new_seq(as.Date(NA_integer_), length_out = 0, obs_only = TRUE),
+    new_seq(as.Date(NA_integer_), .length_out = 0, .obs_only = TRUE),
     as.Date(integer())
   )
   expect_identical(
-    new_seq(as.Date(1L), length_out = 0, obs_only = TRUE),
+    new_seq(as.Date(1L), .length_out = 0, .obs_only = TRUE),
     as.Date(integer())
   )
-  # length_out = 1
-  expect_identical(new_seq(as.Date(c(0L, 1L)), length_out = 1), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(1L, 0L)), length_out = 1), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(1L, 1L)), length_out = 1), as.Date(1L))
-  expect_identical(new_seq(as.Date(c(0L, 0L)), length_out = 1), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(0L, 0L, 1L)), length_out = 1), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(1L, 1L, 0L)), length_out = 1), as.Date(0L))
-  expect_identical(new_seq(as.Date(c(10L, 1L)), length_out = 1), as.Date(5L))
-  expect_identical(new_seq(as.Date(c(100L, 1L)), length_out = 1), as.Date(50L))
+  # .length_out = 1
+  expect_identical(new_seq(as.Date(c(0L, 1L)), .length_out = 1), as.Date(0L))
+  expect_identical(new_seq(as.Date(c(1L, 0L)), .length_out = 1), as.Date(0L))
+  expect_identical(new_seq(as.Date(c(1L, 1L)), .length_out = 1), as.Date(1L))
+  expect_identical(new_seq(as.Date(c(0L, 0L)), .length_out = 1), as.Date(0L))
   expect_identical(
-    new_seq(as.Date(c(0L, 1L)), length_out = 1, obs_only = TRUE),
+    new_seq(as.Date(c(0L, 0L, 1L)), .length_out = 1),
     as.Date(0L)
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 0L)), length_out = 1, obs_only = TRUE),
+    new_seq(as.Date(c(1L, 1L, 0L)), .length_out = 1),
+    as.Date(0L)
+  )
+  expect_identical(new_seq(as.Date(c(10L, 1L)), .length_out = 1), as.Date(5L))
+  expect_identical(new_seq(as.Date(c(100L, 1L)), .length_out = 1), as.Date(50L))
+  expect_identical(
+    new_seq(as.Date(c(0L, 1L)), .length_out = 1, .obs_only = TRUE),
     as.Date(0L)
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 1L)), length_out = 1, obs_only = TRUE),
+    new_seq(as.Date(c(1L, 0L)), .length_out = 1, .obs_only = TRUE),
+    as.Date(0L)
+  )
+  expect_identical(
+    new_seq(as.Date(c(1L, 1L)), .length_out = 1, .obs_only = TRUE),
     as.Date(1L)
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 0L)), length_out = 1, obs_only = TRUE),
+    new_seq(as.Date(c(0L, 0L)), .length_out = 1, .obs_only = TRUE),
     as.Date(0L)
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 0L, 1L)), length_out = 1, obs_only = TRUE),
+    new_seq(as.Date(c(0L, 0L, 1L)), .length_out = 1, .obs_only = TRUE),
     as.Date(0L)
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 1L, 0L)), length_out = 1, obs_only = TRUE),
+    new_seq(as.Date(c(1L, 1L, 0L)), .length_out = 1, .obs_only = TRUE),
     as.Date(0L)
   )
   expect_identical(
-    new_seq(as.Date(c(10L, 1L)), length_out = 1, obs_only = TRUE),
+    new_seq(as.Date(c(10L, 1L)), .length_out = 1, .obs_only = TRUE),
     as.Date(1L)
   )
   expect_identical(
-    new_seq(as.Date(c(100L, 1L)), length_out = 1, obs_only = TRUE),
+    new_seq(as.Date(c(100L, 1L)), .length_out = 1, .obs_only = TRUE),
     as.Date(1L)
   )
-  # length_out = 2
+  # .length_out = 2
   expect_identical(
-    new_seq(as.Date(c(0L, 1L)), length_out = 2),
+    new_seq(as.Date(c(0L, 1L)), .length_out = 2),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 0L)), length_out = 2),
+    new_seq(as.Date(c(1L, 0L)), .length_out = 2),
     as.Date(c(0L, 1L))
   )
-  expect_identical(new_seq(as.Date(c(1L, 1L)), length_out = 2), as.Date(1L))
-  expect_identical(new_seq(as.Date(c(0L, 0L)), length_out = 2), as.Date(0L))
+  expect_identical(new_seq(as.Date(c(1L, 1L)), .length_out = 2), as.Date(1L))
+  expect_identical(new_seq(as.Date(c(0L, 0L)), .length_out = 2), as.Date(0L))
   expect_identical(
-    new_seq(as.Date(c(0L, 0L, 1L)), length_out = 2),
-    as.Date(c(0L, 1L))
-  )
-  expect_identical(
-    new_seq(as.Date(c(1L, 1L, 0L)), length_out = 2),
+    new_seq(as.Date(c(0L, 0L, 1L)), .length_out = 2),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(10L, 1L)), length_out = 2),
+    new_seq(as.Date(c(1L, 1L, 0L)), .length_out = 2),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), .length_out = 2),
     as.Date(c(1L, 10L))
   )
   expect_identical(
-    new_seq(as.Date(c(100L, 1L)), length_out = 2),
+    new_seq(as.Date(c(100L, 1L)), .length_out = 2),
     as.Date(c(1L, 100L))
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 1L)), length_out = 2, obs_only = TRUE),
+    new_seq(as.Date(c(0L, 1L)), .length_out = 2, .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 0L)), length_out = 2, obs_only = TRUE),
+    new_seq(as.Date(c(1L, 0L)), .length_out = 2, .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 1L)), length_out = 2, obs_only = TRUE),
+    new_seq(as.Date(c(1L, 1L)), .length_out = 2, .obs_only = TRUE),
     as.Date(1L)
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 0L)), length_out = 2, obs_only = TRUE),
+    new_seq(as.Date(c(0L, 0L)), .length_out = 2, .obs_only = TRUE),
     as.Date(0L)
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 0L, 1L)), length_out = 2, obs_only = TRUE),
+    new_seq(as.Date(c(0L, 0L, 1L)), .length_out = 2, .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 1L, 0L)), length_out = 2, obs_only = TRUE),
+    new_seq(as.Date(c(1L, 1L, 0L)), .length_out = 2, .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(10L, 1L)), length_out = 2, obs_only = TRUE),
+    new_seq(as.Date(c(10L, 1L)), .length_out = 2, .obs_only = TRUE),
     as.Date(c(1L, 10L))
   )
   expect_identical(
-    new_seq(as.Date(c(100L, 1L)), length_out = 2, obs_only = TRUE),
+    new_seq(as.Date(c(100L, 1L)), .length_out = 2, .obs_only = TRUE),
     as.Date(c(1L, 100L))
   )
-  # length_out = 3
+  # .length_out = 3
   expect_identical(
-    new_seq(as.Date(c(0L, 1L)), length_out = 3),
+    new_seq(as.Date(c(0L, 1L)), .length_out = 3),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 0L)), length_out = 3),
+    new_seq(as.Date(c(1L, 0L)), .length_out = 3),
     as.Date(c(0L, 1L))
   )
-  expect_identical(new_seq(as.Date(c(1L, 1L)), length_out = 3), as.Date(1L))
-  expect_identical(new_seq(as.Date(c(0L, 0L)), length_out = 3), as.Date(0L))
+  expect_identical(new_seq(as.Date(c(1L, 1L)), .length_out = 3), as.Date(1L))
+  expect_identical(new_seq(as.Date(c(0L, 0L)), .length_out = 3), as.Date(0L))
   expect_identical(
-    new_seq(as.Date(c(0L, 0L, 1L)), length_out = 3),
-    as.Date(c(0L, 1L))
-  )
-  expect_identical(
-    new_seq(as.Date(c(1L, 1L, 0L)), length_out = 3),
+    new_seq(as.Date(c(0L, 0L, 1L)), .length_out = 3),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(10L, 1L)), length_out = 3),
+    new_seq(as.Date(c(1L, 1L, 0L)), .length_out = 3),
+    as.Date(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as.Date(c(10L, 1L)), .length_out = 3),
     as.Date(c(1L, 5L, 10L))
   )
   expect_identical(
-    new_seq(as.Date(c(100L, 1L)), length_out = 3),
+    new_seq(as.Date(c(100L, 1L)), .length_out = 3),
     as.Date(c(1L, 50L, 100L))
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 1L)), length_out = 3, obs_only = TRUE),
+    new_seq(as.Date(c(0L, 1L)), .length_out = 3, .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 0L)), length_out = 3, obs_only = TRUE),
+    new_seq(as.Date(c(1L, 0L)), .length_out = 3, .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 1L)), length_out = 3, obs_only = TRUE),
+    new_seq(as.Date(c(1L, 1L)), .length_out = 3, .obs_only = TRUE),
     as.Date(1L)
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 0L)), length_out = 3, obs_only = TRUE),
+    new_seq(as.Date(c(0L, 0L)), .length_out = 3, .obs_only = TRUE),
     as.Date(0L)
   )
   expect_identical(
-    new_seq(as.Date(c(0L, 0L, 1L)), length_out = 3, obs_only = TRUE),
+    new_seq(as.Date(c(0L, 0L, 1L)), .length_out = 3, .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(1L, 1L, 0L)), length_out = 3, obs_only = TRUE),
+    new_seq(as.Date(c(1L, 1L, 0L)), .length_out = 3, .obs_only = TRUE),
     as.Date(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.Date(c(10L, 1L)), length_out = 3, obs_only = TRUE),
+    new_seq(as.Date(c(10L, 1L)), .length_out = 3, .obs_only = TRUE),
     as.Date(c(1L, 10L))
   )
   expect_identical(
-    new_seq(as.Date(c(100L, 1L)), length_out = 3, obs_only = TRUE),
+    new_seq(as.Date(c(100L, 1L)), .length_out = 3, .obs_only = TRUE),
     as.Date(c(1L, 100L))
   )
-  # length_out = Inf
+  # .length_out = Inf
   expect_identical(
-    new_seq(as.Date(c(10L, 1L)), length_out = Inf),
+    new_seq(as.Date(c(10L, 1L)), .length_out = Inf),
     as.Date(1:10)
   )
   expect_identical(
-    new_seq(as.Date(c(100L, 1L)), length_out = Inf),
+    new_seq(as.Date(c(100L, 1L)), .length_out = Inf),
     as.Date(c(1:100))
   )
   expect_identical(
-    new_seq(as.Date(c(10L, 1L)), length_out = Inf, obs_only = TRUE),
+    new_seq(as.Date(c(10L, 1L)), .length_out = Inf, .obs_only = TRUE),
     as.Date(c(1L, 10L))
   )
   expect_identical(
-    new_seq(as.Date(c(100L, 1L)), length_out = Inf, obs_only = TRUE),
+    new_seq(as.Date(c(100L, 1L)), .length_out = Inf, .obs_only = TRUE),
     as.Date(c(1L, 100L))
   )
 })
@@ -1860,160 +1899,160 @@ test_that("new_seq POSIXct", {
   )
   # # length_out not count
   expect_error(
-    new_seq(as.POSIXct(1L), length_out = -1),
-    "`length_out` must be a count"
+    new_seq(as.POSIXct(1L), .length_out = -1),
+    "`.length_out` must be a count"
   )
   expect_error(
-    new_seq(as.POSIXct(1L), length_out = 0.5),
-    "`length_out` must be a count"
+    new_seq(as.POSIXct(1L), .length_out = 0.5),
+    "`.length_out` must be a count"
   )
   # length_out is 0
   expect_identical(
-    new_seq(as.POSIXct(integer()), length_out = 0),
+    new_seq(as.POSIXct(integer()), .length_out = 0),
     as.POSIXct(integer())
   )
   expect_identical(
-    new_seq(as.POSIXct(NA_integer_), length_out = 0),
+    new_seq(as.POSIXct(NA_integer_), .length_out = 0),
     as.POSIXct(integer())
   )
   expect_identical(
-    new_seq(as.POSIXct(1L), length_out = 0),
+    new_seq(as.POSIXct(1L), .length_out = 0),
     as.POSIXct(integer())
   )
   expect_identical(
-    new_seq(as.POSIXct(integer(), tz = "PST8PDT"), length_out = 0),
+    new_seq(as.POSIXct(integer(), tz = "PST8PDT"), .length_out = 0),
     as.POSIXct(integer(), tz = "PST8PDT")
   )
   expect_identical(
-    new_seq(as.POSIXct(NA_integer_, tz = "PST8PDT"), length_out = 0),
+    new_seq(as.POSIXct(NA_integer_, tz = "PST8PDT"), .length_out = 0),
     as.POSIXct(integer(), tz = "PST8PDT")
   )
   expect_identical(
-    new_seq(as.POSIXct(1L, tz = "PST8PDT"), length_out = 0),
+    new_seq(as.POSIXct(1L, tz = "PST8PDT"), .length_out = 0),
     as.POSIXct(integer(), tz = "PST8PDT")
   )
-  # length_out = 1
+  # .length_out = 1
   expect_identical(
-    new_seq(as.POSIXct(c(0L, 1L)), length_out = 1),
+    new_seq(as.POSIXct(c(0L, 1L)), .length_out = 1),
     as.POSIXct(0L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(1L, 0L)), length_out = 1),
+    new_seq(as.POSIXct(c(1L, 0L)), .length_out = 1),
     as.POSIXct(0L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(1L, 1L)), length_out = 1),
+    new_seq(as.POSIXct(c(1L, 1L)), .length_out = 1),
     as.POSIXct(1L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(0L, 0L)), length_out = 1),
+    new_seq(as.POSIXct(c(0L, 0L)), .length_out = 1),
     as.POSIXct(0L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(0L, 0L, 1L)), length_out = 1),
+    new_seq(as.POSIXct(c(0L, 0L, 1L)), .length_out = 1),
     as.POSIXct(0L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(1L, 1L, 0L)), length_out = 1),
+    new_seq(as.POSIXct(c(1L, 1L, 0L)), .length_out = 1),
     as.POSIXct(0L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(10L, 1L)), length_out = 1),
+    new_seq(as.POSIXct(c(10L, 1L)), .length_out = 1),
     as.POSIXct(5L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(100L, 1L)), length_out = 1),
+    new_seq(as.POSIXct(c(100L, 1L)), .length_out = 1),
     as.POSIXct(50L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), length_out = 1),
+    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), .length_out = 1),
     as.POSIXct(50L, tz = "PST8PDT")
   )
-  # length_out = 2
+  # .length_out = 2
   expect_identical(
-    new_seq(as.POSIXct(c(0L, 1L)), length_out = 2),
+    new_seq(as.POSIXct(c(0L, 1L)), .length_out = 2),
     as.POSIXct(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(1L, 0L)), length_out = 2),
+    new_seq(as.POSIXct(c(1L, 0L)), .length_out = 2),
     as.POSIXct(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(1L, 1L)), length_out = 2),
+    new_seq(as.POSIXct(c(1L, 1L)), .length_out = 2),
     as.POSIXct(1L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(0L, 0L)), length_out = 2),
+    new_seq(as.POSIXct(c(0L, 0L)), .length_out = 2),
     as.POSIXct(0L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(0L, 0L, 1L)), length_out = 2),
+    new_seq(as.POSIXct(c(0L, 0L, 1L)), .length_out = 2),
     as.POSIXct(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(1L, 1L, 0L)), length_out = 2),
+    new_seq(as.POSIXct(c(1L, 1L, 0L)), .length_out = 2),
     as.POSIXct(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(10L, 1L)), length_out = 2),
+    new_seq(as.POSIXct(c(10L, 1L)), .length_out = 2),
     as.POSIXct(c(1L, 10L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(100L, 1L)), length_out = 2),
+    new_seq(as.POSIXct(c(100L, 1L)), .length_out = 2),
     as.POSIXct(c(1L, 100L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), length_out = 2),
+    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), .length_out = 2),
     as.POSIXct(c(1L, 100L), tz = "PST8PDT")
   )
-  # length_out = 3
+  # .length_out = 3
   expect_identical(
-    new_seq(as.POSIXct(c(0L, 1L)), length_out = 3),
+    new_seq(as.POSIXct(c(0L, 1L)), .length_out = 3),
     as.POSIXct(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(1L, 0L)), length_out = 3),
+    new_seq(as.POSIXct(c(1L, 0L)), .length_out = 3),
     as.POSIXct(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(1L, 1L)), length_out = 3),
+    new_seq(as.POSIXct(c(1L, 1L)), .length_out = 3),
     as.POSIXct(1L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(0L, 0L)), length_out = 3),
+    new_seq(as.POSIXct(c(0L, 0L)), .length_out = 3),
     as.POSIXct(0L)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(0L, 0L, 1L)), length_out = 3),
+    new_seq(as.POSIXct(c(0L, 0L, 1L)), .length_out = 3),
     as.POSIXct(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(1L, 1L, 0L)), length_out = 3),
+    new_seq(as.POSIXct(c(1L, 1L, 0L)), .length_out = 3),
     as.POSIXct(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(10L, 1L)), length_out = 3),
+    new_seq(as.POSIXct(c(10L, 1L)), .length_out = 3),
     as.POSIXct(c(1L, 5L, 10L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(100L, 1L)), length_out = 3),
+    new_seq(as.POSIXct(c(100L, 1L)), .length_out = 3),
     as.POSIXct(c(1L, 50L, 100L))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), length_out = 3),
+    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), .length_out = 3),
     as.POSIXct(c(1L, 50L, 100L), tz = "PST8PDT")
   )
-  # length_out = Inf
+  # .length_out = Inf
   expect_identical(
-    new_seq(as.POSIXct(c(10L, 1L)), length_out = Inf),
+    new_seq(as.POSIXct(c(10L, 1L)), .length_out = Inf),
     as.POSIXct(1:10)
   )
   expect_identical(
-    new_seq(as.POSIXct(c(100L, 1L)), length_out = Inf),
+    new_seq(as.POSIXct(c(100L, 1L)), .length_out = Inf),
     as.POSIXct(c(1:100))
   )
   expect_identical(
-    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), length_out = Inf),
+    new_seq(as.POSIXct(c(100L, 1L), tz = "PST8PDT"), .length_out = Inf),
     as.POSIXct(c(1:100), tz = "PST8PDT")
   )
 })
@@ -2119,93 +2158,93 @@ test_that("new_seq hms", {
   )
   # length_out not count
   expect_error(
-    new_seq(as_hms(1L), length_out = -1),
-    "`length_out` must be a count"
+    new_seq(as_hms(1L), .length_out = -1),
+    "`.length_out` must be a count"
   )
   expect_error(
-    new_seq(as_hms(1L), length_out = 0.5),
-    "`length_out` must be a count"
+    new_seq(as_hms(1L), .length_out = 0.5),
+    "`.length_out` must be a count"
   )
   # length_out is 0
   expect_identical(
-    new_seq(as_hms(integer()), length_out = 0),
+    new_seq(as_hms(integer()), .length_out = 0),
     as_hms(integer())
   )
   expect_identical(
-    new_seq(as_hms(NA_integer_), length_out = 0),
+    new_seq(as_hms(NA_integer_), .length_out = 0),
     as_hms(integer())
   )
   expect_identical(
-    new_seq(as_hms(1L), length_out = 0),
+    new_seq(as_hms(1L), .length_out = 0),
     as_hms(integer())
   )
-  # length_out = 1
-  expect_identical(new_seq(as_hms(c(0L, 1L)), length_out = 1), as_hms(0L))
-  expect_identical(new_seq(as_hms(c(1L, 0L)), length_out = 1), as_hms(0L))
-  expect_identical(new_seq(as_hms(c(1L, 1L)), length_out = 1), as_hms(1L))
-  expect_identical(new_seq(as_hms(c(0L, 0L)), length_out = 1), as_hms(0L))
-  expect_identical(new_seq(as_hms(c(0L, 0L, 1L)), length_out = 1), as_hms(0L))
-  expect_identical(new_seq(as_hms(c(1L, 1L, 0L)), length_out = 1), as_hms(0L))
-  expect_identical(new_seq(as_hms(c(10L, 1L)), length_out = 1), as_hms(5L))
-  expect_identical(new_seq(as_hms(c(100L, 1L)), length_out = 1), as_hms(50L))
-  # length_out = 2
+  # .length_out = 1
+  expect_identical(new_seq(as_hms(c(0L, 1L)), .length_out = 1), as_hms(0L))
+  expect_identical(new_seq(as_hms(c(1L, 0L)), .length_out = 1), as_hms(0L))
+  expect_identical(new_seq(as_hms(c(1L, 1L)), .length_out = 1), as_hms(1L))
+  expect_identical(new_seq(as_hms(c(0L, 0L)), .length_out = 1), as_hms(0L))
+  expect_identical(new_seq(as_hms(c(0L, 0L, 1L)), .length_out = 1), as_hms(0L))
+  expect_identical(new_seq(as_hms(c(1L, 1L, 0L)), .length_out = 1), as_hms(0L))
+  expect_identical(new_seq(as_hms(c(10L, 1L)), .length_out = 1), as_hms(5L))
+  expect_identical(new_seq(as_hms(c(100L, 1L)), .length_out = 1), as_hms(50L))
+  # .length_out = 2
   expect_identical(
-    new_seq(as_hms(c(0L, 1L)), length_out = 2),
+    new_seq(as_hms(c(0L, 1L)), .length_out = 2),
     as_hms(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as_hms(c(1L, 0L)), length_out = 2),
+    new_seq(as_hms(c(1L, 0L)), .length_out = 2),
     as_hms(c(0L, 1L))
   )
-  expect_identical(new_seq(as_hms(c(1L, 1L)), length_out = 2), as_hms(1L))
-  expect_identical(new_seq(as_hms(c(0L, 0L)), length_out = 2), as_hms(0L))
+  expect_identical(new_seq(as_hms(c(1L, 1L)), .length_out = 2), as_hms(1L))
+  expect_identical(new_seq(as_hms(c(0L, 0L)), .length_out = 2), as_hms(0L))
   expect_identical(
-    new_seq(as_hms(c(0L, 0L, 1L)), length_out = 2),
-    as_hms(c(0L, 1L))
-  )
-  expect_identical(
-    new_seq(as_hms(c(1L, 1L, 0L)), length_out = 2),
+    new_seq(as_hms(c(0L, 0L, 1L)), .length_out = 2),
     as_hms(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as_hms(c(10L, 1L)), length_out = 2),
+    new_seq(as_hms(c(1L, 1L, 0L)), .length_out = 2),
+    as_hms(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as_hms(c(10L, 1L)), .length_out = 2),
     as_hms(c(1L, 10L))
   )
   expect_identical(
-    new_seq(as_hms(c(100L, 1L)), length_out = 2),
+    new_seq(as_hms(c(100L, 1L)), .length_out = 2),
     as_hms(c(1L, 100L))
   )
-  # length_out = 3
+  # .length_out = 3
   expect_identical(
-    new_seq(as_hms(c(0L, 1L)), length_out = 3),
+    new_seq(as_hms(c(0L, 1L)), .length_out = 3),
     as_hms(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as_hms(c(1L, 0L)), length_out = 3),
+    new_seq(as_hms(c(1L, 0L)), .length_out = 3),
     as_hms(c(0L, 1L))
   )
-  expect_identical(new_seq(as_hms(c(1L, 1L)), length_out = 3), as_hms(1L))
-  expect_identical(new_seq(as_hms(c(0L, 0L)), length_out = 3), as_hms(0L))
+  expect_identical(new_seq(as_hms(c(1L, 1L)), .length_out = 3), as_hms(1L))
+  expect_identical(new_seq(as_hms(c(0L, 0L)), .length_out = 3), as_hms(0L))
   expect_identical(
-    new_seq(as_hms(c(0L, 0L, 1L)), length_out = 3),
-    as_hms(c(0L, 1L))
-  )
-  expect_identical(
-    new_seq(as_hms(c(1L, 1L, 0L)), length_out = 3),
+    new_seq(as_hms(c(0L, 0L, 1L)), .length_out = 3),
     as_hms(c(0L, 1L))
   )
   expect_identical(
-    new_seq(as_hms(c(10L, 1L)), length_out = 3),
+    new_seq(as_hms(c(1L, 1L, 0L)), .length_out = 3),
+    as_hms(c(0L, 1L))
+  )
+  expect_identical(
+    new_seq(as_hms(c(10L, 1L)), .length_out = 3),
     as_hms(c(1L, 5L, 10L))
   )
   expect_identical(
-    new_seq(as_hms(c(100L, 1L)), length_out = 3),
+    new_seq(as_hms(c(100L, 1L)), .length_out = 3),
     as_hms(c(1L, 50L, 100L))
   )
-  # length_out = Inf
-  expect_identical(new_seq(as_hms(c(10L, 1L)), length_out = Inf), as_hms(1:10))
+  # .length_out = Inf
+  expect_identical(new_seq(as_hms(c(10L, 1L)), .length_out = Inf), as_hms(1:10))
   expect_identical(
-    new_seq(as_hms(c(100L, 1L)), length_out = Inf),
+    new_seq(as_hms(c(100L, 1L)), .length_out = Inf),
     as_hms(c(1:100))
   )
 })

--- a/tests/testthat/test-new-value.R
+++ b/tests/testthat/test-new-value.R
@@ -1,33 +1,33 @@
 test_that("new_value logical", {
   # zero length
   expect_identical(new_value(logical()), FALSE)
-  expect_identical(new_value(logical(), obs_only = TRUE), NA)
+  expect_identical(new_value(logical(), .obs_only = TRUE), NA)
   # missing value
   expect_identical(new_value(NA), FALSE)
-  expect_identical(new_value(NA, obs_only = TRUE), NA)
+  expect_identical(new_value(NA, .obs_only = TRUE), NA)
   # single value
   expect_identical(new_value(FALSE), FALSE)
   expect_identical(new_value(TRUE), FALSE)
-  expect_identical(new_value(FALSE, obs_only = TRUE), FALSE)
-  expect_identical(new_value(TRUE, obs_only = TRUE), TRUE)
+  expect_identical(new_value(FALSE, .obs_only = TRUE), FALSE)
+  expect_identical(new_value(TRUE, .obs_only = TRUE), TRUE)
   # multiple values
   expect_identical(new_value(c(TRUE, FALSE)), FALSE)
   expect_identical(new_value(c(FALSE, TRUE)), FALSE)
   expect_identical(new_value(c(TRUE, TRUE)), FALSE)
   expect_identical(new_value(c(TRUE, TRUE, FALSE)), FALSE)
-  expect_identical(new_value(c(TRUE, FALSE), obs_only = TRUE), FALSE)
-  expect_identical(new_value(c(FALSE, TRUE), obs_only = TRUE), FALSE)
-  expect_identical(new_value(c(TRUE, TRUE), obs_only = TRUE), TRUE)
-  expect_identical(new_value(c(TRUE, TRUE, FALSE), obs_only = TRUE), FALSE)
+  expect_identical(new_value(c(TRUE, FALSE), .obs_only = TRUE), FALSE)
+  expect_identical(new_value(c(FALSE, TRUE), .obs_only = TRUE), FALSE)
+  expect_identical(new_value(c(TRUE, TRUE), .obs_only = TRUE), TRUE)
+  expect_identical(new_value(c(TRUE, TRUE, FALSE), .obs_only = TRUE), FALSE)
   # multiple values with missing
   expect_identical(new_value(c(TRUE, FALSE, NA)), FALSE)
   expect_identical(new_value(c(FALSE, TRUE, NA)), FALSE)
   expect_identical(new_value(c(TRUE, TRUE, NA)), FALSE)
   expect_identical(new_value(c(TRUE, TRUE, FALSE, NA)), FALSE)
-  expect_identical(new_value(c(TRUE, FALSE, NA), obs_only = TRUE), FALSE)
-  expect_identical(new_value(c(FALSE, TRUE, NA), obs_only = TRUE), FALSE)
-  expect_identical(new_value(c(TRUE, TRUE, NA), obs_only = TRUE), TRUE)
-  expect_identical(new_value(c(TRUE, TRUE, FALSE, NA), obs_only = TRUE), FALSE)
+  expect_identical(new_value(c(TRUE, FALSE, NA), .obs_only = TRUE), FALSE)
+  expect_identical(new_value(c(FALSE, TRUE, NA), .obs_only = TRUE), FALSE)
+  expect_identical(new_value(c(TRUE, TRUE, NA), .obs_only = TRUE), TRUE)
+  expect_identical(new_value(c(TRUE, TRUE, FALSE, NA), .obs_only = TRUE), FALSE)
   # matrices and arrays
   expect_identical(new_value(matrix(TRUE)), FALSE)
   expect_identical(new_value(array(TRUE)), FALSE)
@@ -36,44 +36,44 @@ test_that("new_value logical", {
 test_that("new_value integer", {
   # zero length
   expect_identical(new_value(integer()), NA_integer_)
-  expect_identical(new_value(integer(), obs_only = TRUE), NA_integer_)
+  expect_identical(new_value(integer(), .obs_only = TRUE), NA_integer_)
   # missing value
   expect_identical(new_value(NA_integer_), NA_integer_)
-  expect_identical(new_value(NA_integer_, obs_only = TRUE), NA_integer_)
+  expect_identical(new_value(NA_integer_, .obs_only = TRUE), NA_integer_)
   # single value
   expect_identical(new_value(1L), 1L)
   expect_identical(new_value(10L), 10L)
   expect_identical(new_value(-1L), -1L)
   expect_identical(new_value(0L), 0L)
-  expect_identical(new_value(1L, obs_only = TRUE), 1L)
-  expect_identical(new_value(10L, obs_only = TRUE), 10L)
-  expect_identical(new_value(-1L, obs_only = TRUE), -1L)
-  expect_identical(new_value(0L, obs_only = TRUE), 0L)
+  expect_identical(new_value(1L, .obs_only = TRUE), 1L)
+  expect_identical(new_value(10L, .obs_only = TRUE), 10L)
+  expect_identical(new_value(-1L, .obs_only = TRUE), -1L)
+  expect_identical(new_value(0L, .obs_only = TRUE), 0L)
   # multiple values
   expect_identical(new_value(0:1), 0L)
   expect_identical(new_value(1:2), 1L)
   expect_identical(new_value(c(1L, 3L)), 2L)
-  expect_identical(new_value(0:1, obs_only = TRUE), 0L)
-  expect_identical(new_value(1:2, obs_only = TRUE), 1L)
-  expect_identical(new_value(c(1L, 3L), obs_only = TRUE), 1L)
+  expect_identical(new_value(0:1, .obs_only = TRUE), 0L)
+  expect_identical(new_value(1:2, .obs_only = TRUE), 1L)
+  expect_identical(new_value(c(1L, 3L), .obs_only = TRUE), 1L)
   # multiple values with missing
   expect_identical(new_value(c(0:1, NA)), 0L)
   expect_identical(new_value(c(1:2, NA)), 1L)
   expect_identical(new_value(c(1L, 3L, NA)), 2L)
-  expect_identical(new_value(c(0:1, NA), obs_only = TRUE), 0L)
-  expect_identical(new_value(c(1:2, NA), obs_only = TRUE), 1L)
-  expect_identical(new_value(c(1L, 3L, NA), obs_only = TRUE), 1L)
+  expect_identical(new_value(c(0:1, NA), .obs_only = TRUE), 0L)
+  expect_identical(new_value(c(1:2, NA), .obs_only = TRUE), 1L)
+  expect_identical(new_value(c(1L, 3L, NA), .obs_only = TRUE), 1L)
   # matrices and arrays
   expect_identical(new_value(matrix(1L)), 1L)
   expect_identical(new_value(array(1L)), 1L)
   # median
-  expect_identical(new_value(c(0:1), obs_only = TRUE), as.integer(median(0:1)))
+  expect_identical(new_value(c(0:1), .obs_only = TRUE), as.integer(median(0:1)))
   expect_identical(
-    new_value(c(1:10), obs_only = TRUE),
+    new_value(c(1:10), .obs_only = TRUE),
     as.integer(median(1:10))
   )
   expect_identical(
-    new_value(c(2:10), obs_only = TRUE),
+    new_value(c(2:10), .obs_only = TRUE),
     as.integer(median(2:10))
   )
 })
@@ -105,35 +105,35 @@ test_that("new_value integer obs_only", {
 test_that("new_value real", {
   # zero length
   expect_identical(new_value(double()), NA_real_)
-  expect_identical(new_value(double(), obs_only = TRUE), NA_real_)
+  expect_identical(new_value(double(), .obs_only = TRUE), NA_real_)
   # missing value
   expect_identical(new_value(NA_real_), NA_real_)
-  expect_identical(new_value(NA_real_, obs_only = TRUE), NA_real_)
+  expect_identical(new_value(NA_real_, .obs_only = TRUE), NA_real_)
   # single value
   expect_identical(new_value(1), 1)
   expect_identical(new_value(1.1), 1.1)
   expect_identical(new_value(10), 10)
   expect_identical(new_value(-1), -1)
   expect_identical(new_value(0), 0)
-  expect_identical(new_value(1, obs_only = TRUE), 1)
-  expect_identical(new_value(1.1, obs_only = TRUE), 1.1)
-  expect_identical(new_value(10, obs_only = TRUE), 10)
-  expect_identical(new_value(-1, obs_only = TRUE), -1)
-  expect_identical(new_value(0, obs_only = TRUE), 0)
+  expect_identical(new_value(1, .obs_only = TRUE), 1)
+  expect_identical(new_value(1.1, .obs_only = TRUE), 1.1)
+  expect_identical(new_value(10, .obs_only = TRUE), 10)
+  expect_identical(new_value(-1, .obs_only = TRUE), -1)
+  expect_identical(new_value(0, .obs_only = TRUE), 0)
   # multiple values
   expect_identical(new_value(c(0, 1)), 0.5)
   expect_identical(new_value(c(1, 2)), 1.5)
   expect_identical(new_value(c(1, 3)), 2)
-  expect_identical(new_value(c(0, 1), obs_only = TRUE), 0)
-  expect_identical(new_value(c(1, 2), obs_only = TRUE), 1)
-  expect_identical(new_value(c(1, 3), obs_only = TRUE), 1)
+  expect_identical(new_value(c(0, 1), .obs_only = TRUE), 0)
+  expect_identical(new_value(c(1, 2), .obs_only = TRUE), 1)
+  expect_identical(new_value(c(1, 3), .obs_only = TRUE), 1)
   # multiple values with missing
   expect_identical(new_value(c(0, 1, NA)), 0.5)
   expect_identical(new_value(c(1, 2, NA)), 1.5)
   expect_identical(new_value(c(1, 3, NA)), 2)
-  expect_identical(new_value(c(0, 1, NA), obs_only = TRUE), 0)
-  expect_identical(new_value(c(1, 2, NA), obs_only = TRUE), 1)
-  expect_identical(new_value(c(1, 3, NA), obs_only = TRUE), 1)
+  expect_identical(new_value(c(0, 1, NA), .obs_only = TRUE), 0)
+  expect_identical(new_value(c(1, 2, NA), .obs_only = TRUE), 1)
+  expect_identical(new_value(c(1, 3, NA), .obs_only = TRUE), 1)
   # matrices and arrays
   expect_identical(new_value(matrix(1)), 1)
   expect_identical(new_value(array(1)), 1)
@@ -162,10 +162,10 @@ test_that("new_value character", {
 test_that("new_value factor", {
   # zero length
   expect_identical(new_value(factor()), factor(NA))
-  expect_identical(new_value(factor(), obs_only = TRUE), factor(NA))
+  expect_identical(new_value(factor(), .obs_only = TRUE), factor(NA))
   # missing value
   expect_identical(new_value(factor(NA)), factor(NA))
-  expect_identical(new_value(factor(NA), obs_only = TRUE), factor(NA))
+  expect_identical(new_value(factor(NA), .obs_only = TRUE), factor(NA))
   # single value
   expect_identical(
     new_value(factor("b", levels = "b")),
@@ -241,7 +241,7 @@ test_that("new_value ordered", {
     factor(0, levels = c(0:2))
   )
   expect_identical(
-    new_value(factor(1:2, levels = c(0:2)), obs_only = TRUE),
+    new_value(factor(1:2, levels = c(0:2)), .obs_only = TRUE),
     factor(1, levels = c(0:2))
   )
 })
@@ -326,15 +326,15 @@ test_that("new_value Date", {
   expect_identical(new_value(as.Date(integer())), as.Date(NA_integer_))
   expect_identical(new_value(as.Date(double())), as.Date(NA_integer_))
   expect_identical(
-    new_value(as.Date(character()), obs_only = TRUE),
+    new_value(as.Date(character()), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   expect_identical(
-    new_value(as.Date(integer()), obs_only = TRUE),
+    new_value(as.Date(integer()), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   expect_identical(
-    new_value(as.Date(double()), obs_only = TRUE),
+    new_value(as.Date(double()), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   # missing value
@@ -342,15 +342,15 @@ test_that("new_value Date", {
   expect_identical(new_value(as.Date(NA_real_)), as.Date(NA_integer_))
   expect_identical(new_value(as.Date(NA_integer_)), as.Date(NA_integer_))
   expect_identical(
-    new_value(as.Date(NA_character_), obs_only = TRUE),
+    new_value(as.Date(NA_character_), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   expect_identical(
-    new_value(as.Date(NA_real_), obs_only = TRUE),
+    new_value(as.Date(NA_real_), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   expect_identical(
-    new_value(as.Date(NA_integer_), obs_only = TRUE),
+    new_value(as.Date(NA_integer_), .obs_only = TRUE),
     as.Date(NA_integer_)
   )
   # single value
@@ -359,32 +359,32 @@ test_that("new_value Date", {
   expect_identical(new_value(as.Date(1.1)), as.Date(1L))
   expect_identical(new_value(as.Date(1.6)), as.Date(1L))
   expect_identical(new_value(as.Date(10)), as.Date(10L))
-  expect_identical(new_value(as.Date(1L), obs_only = TRUE), as.Date(1L))
-  expect_identical(new_value(as.Date(1), obs_only = TRUE), as.Date(1L))
-  expect_identical(new_value(as.Date(1.1), obs_only = TRUE), as.Date(1L))
-  expect_identical(new_value(as.Date(1.6), obs_only = TRUE), as.Date(1L))
-  expect_identical(new_value(as.Date(10), obs_only = TRUE), as.Date(10L))
+  expect_identical(new_value(as.Date(1L), .obs_only = TRUE), as.Date(1L))
+  expect_identical(new_value(as.Date(1), .obs_only = TRUE), as.Date(1L))
+  expect_identical(new_value(as.Date(1.1), .obs_only = TRUE), as.Date(1L))
+  expect_identical(new_value(as.Date(1.6), .obs_only = TRUE), as.Date(1L))
+  expect_identical(new_value(as.Date(10), .obs_only = TRUE), as.Date(10L))
   # multiple values
   expect_identical(new_value(as.Date(c(0, 1))), as.Date(0L))
   expect_identical(new_value(as.Date(c(1, 2))), as.Date(1L))
   expect_identical(new_value(as.Date(c(1, 3))), as.Date(2L))
-  expect_identical(new_value(as.Date(c(0, 1)), obs_only = TRUE), as.Date(0L))
-  expect_identical(new_value(as.Date(c(1, 2)), obs_only = TRUE), as.Date(1L))
-  expect_identical(new_value(as.Date(c(1, 3)), obs_only = TRUE), as.Date(1L))
+  expect_identical(new_value(as.Date(c(0, 1)), .obs_only = TRUE), as.Date(0L))
+  expect_identical(new_value(as.Date(c(1, 2)), .obs_only = TRUE), as.Date(1L))
+  expect_identical(new_value(as.Date(c(1, 3)), .obs_only = TRUE), as.Date(1L))
   # multiple values with missing
   expect_identical(new_value(as.Date(c(0, 1, NA))), as.Date(0L))
   expect_identical(new_value(as.Date(c(1, 2, NA))), as.Date(1L))
   expect_identical(new_value(as.Date(c(1, 3, NA))), as.Date(2L))
   expect_identical(
-    new_value(as.Date(c(0, 1, NA)), obs_only = TRUE),
+    new_value(as.Date(c(0, 1, NA)), .obs_only = TRUE),
     as.Date(0L)
   )
   expect_identical(
-    new_value(as.Date(c(1, 2, NA)), obs_only = TRUE),
+    new_value(as.Date(c(1, 2, NA)), .obs_only = TRUE),
     as.Date(1L)
   )
   expect_identical(
-    new_value(as.Date(c(1, 3, NA)), obs_only = TRUE),
+    new_value(as.Date(c(1, 3, NA)), .obs_only = TRUE),
     as.Date(1L)
   )
 })

--- a/tests/testthat/test-readme.R
+++ b/tests/testthat/test-readme.R
@@ -2,8 +2,8 @@ test_that("readme examples", {
   testthat::expect_snapshot({
     xnew_data(old_data)
     xnew_data(old_data, int)
-    xnew_data(old_data, xnew_seq(int, length_out = 3))
-    xnew_data(old_data, xnew_seq(int, length_out = 3, obs_only = TRUE))
+    xnew_data(old_data, xnew_seq(int, .length_out = 3))
+    xnew_data(old_data, xnew_seq(int, .length_out = 3, .obs_only = TRUE))
     xnew_data(old_data, int, fct)
     xnew_data(old_data, xobs_only(int, fct))
     xnew_data(old_data, new = c(TRUE, FALSE))

--- a/tests/testthat/test-xnew-data.R
+++ b/tests/testthat/test-xnew-data.R
@@ -19,10 +19,10 @@ test_that("simple dataset", {
     xnew_data(data, c)
     xnew_data(data, xnew_seq(c))
     xnew_data(data, xnew_seq(a))
-    xnew_data(data, xnew_seq(a, length_out = 12))
-    xnew_data(data, xnew_seq(a, length_out = 12, obs_only = TRUE))
-    xnew_data(data, xnew_seq(a, length_out = 12), b)
-    xnew_data(data, b, xnew_seq(a, length_out = 12))
+    xnew_data(data, xnew_seq(a, .length_out = 12))
+    xnew_data(data, xnew_seq(a, .length_out = 12, .obs_only = TRUE))
+    xnew_data(data, xnew_seq(a, .length_out = 12), b)
+    xnew_data(data, b, xnew_seq(a, .length_out = 12))
     xnew_data(data, tidyr::nesting(c, d))
     xnew_data(
       data,
@@ -89,7 +89,7 @@ test_that("factors", {
     data
     xnew_data(data)
     xnew_data(data, xnew_value(annual))
-    xnew_data(data, xnew_value(annual, obs_only = TRUE))
+    xnew_data(data, xnew_value(annual, .obs_only = TRUE))
     xnew_data(data, tidyr::nesting(period, year))
     xnew_data(data, tidyr::nesting(period, year, annual))
     # FIXME: possible to nest on new_value?


### PR DESCRIPTION
Closes #43. Supersedes #90 (same change rebuilt from current main as three reviewable commits).

## What

Standardizes the argument names so the dotted spelling used by `xnew_data(.length_out)` / `xobs_only(.length_out)` is also used by `new_seq()` and `new_value()`, in three commits:

1. **Add new arguments** - `new_seq()` (generic + all 8 methods) and `new_value()` gain `.length_out` / `.obs_only`; the old spellings move after `...` and continue to work silently. Every method and `new_value()` now validate `...` with `chk_unused(...)`. Internals, tests and snapshots switch to the dotted names.
2. **Deprecate old arguments** - `length_out` / `obs_only` become `deprecated()` formals that emit `lifecycle::deprecate_warn("0.1.0", ...)`. Explicit `expect_snapshot()` tests record the lifecycle messages (direct calls, S3 dispatch via Date, `new_value()`, and forwarding through `xnew_seq()`).
3. **Update documentation** - roxygen prose, examples, README and man pages switch to the dotted spelling; output is unchanged.

## How

- The generic emits the deprecation warning (correct caller attribution); methods coalesce the old names silently via a small `new_seq_args()` helper. This split is necessary because `UseMethod()` does not propagate a value remapped in the generic body.
- `xnew_seq()` / `xnew_value()` forward `...` unchanged, so they accept both spellings; the internal `xnew_data()` / `xobs_only()` exprs now build the dotted names.
- `deprecate_warn()` (rather than `deprecate_soft()`) so the common indirect usage `xnew_data(data, xnew_seq(col, length_out = ...))` warns too, not only direct `new_seq()` calls. Version left at 0.1.0; NEWS.md left to fledge.
- `chk_unused(...)` exposed a broken `new_value()` example that passed `tzone` to `new_value()` (silently swallowed by `...`) instead of `tz` to `as.POSIXct()`; fixed in the docs commit.
- `new_data()` is untouched as it retains its own argument names.

Full test suite (993 tests) and `R CMD check` pass (0 errors, 0 warnings, 2 pre-existing notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)